### PR TITLE
add remaining crud funcs, add locking to entries to prevent race conditions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       - dependency-type: "all"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "EtienneM"
     groups:
       dependencies:
         patterns:
@@ -17,5 +15,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "EtienneM"

--- a/.sclng/metadata.toml
+++ b/.sclng/metadata.toml
@@ -1,7 +1,0 @@
-dependencies = []
-description = "Distributed and fault tolerant cron"
-flags = ["lib"]
-languages = ["go"]
-owner = "etienne@scalingo.com"
-team = "IST"
-version = "1.1.0"


### PR DESCRIPTION
Add the rest of the CRUD methods:

- GetJob
- DeleteJob
- ListJobsByPrefix, where the prefix we pass in is the appID + "||"

Also added a mutex to entries and cleaned up a bit