### PR TITLE
Fix multiple races and bug with collector

### DIFF
--- a/.examples/cron_example.go
+++ b/.examples/cron_example.go
@@ -49,7 +49,8 @@ func main() {
 	cron, err := etcdcron.New(
 		etcdcron.WithNamespace(namespace),
 		etcdcron.WithPartitioning(p),
-		etcdcron.WithTriggerFunc(func(ctx context.Context, metadata map[string]string, payload *anypb.Any) (etcdcron.TriggerResult, error) {
+		etcdcron.WithTriggerFunc(func(ctx context.Context, req etcdcron.TriggerRequest) (etcdcron.TriggerResult, error) {
+			metadata := req.Metadata
 			if metadata["failure"] == "yes" {
 				// Failure does not trigger the errorsHandler() callback. It just skips the counter update.
 				return etcdcron.Failure, nil
@@ -59,7 +60,7 @@ func main() {
 					return etcdcron.Delete, nil
 				}
 			}
-			log.Printf("Trigger from pid %d: %s\n", os.Getpid(), string(payload.Value))
+			log.Printf("Trigger from pid %d: %s\n", os.Getpid(), string(req.Payload.Value))
 			return etcdcron.OK, nil
 		}),
 	)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -36,8 +36,9 @@ func TestAddEntryAfterStart(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	collector.Add(func(ctx context.Context) {
+	collector.Add(func(ctx context.Context) error {
 		wg.Done()
+		return nil
 	})
 
 	select {
@@ -55,8 +56,9 @@ func TestAddEntryBeforeStart(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	collector.Add(func(ctx context.Context) {
+	collector.Add(func(ctx context.Context) error {
 		wg.Done()
+		return nil
 	})
 
 	collector.Start(ctx)
@@ -82,16 +84,18 @@ func TestExpireOnlyOneOutOfTwo(t *testing.T) {
 	called1 := atomic.Bool{}
 	called2 := atomic.Bool{}
 
-	collector.Add(func(ctx context.Context) {
+	collector.Add(func(ctx context.Context) error {
 		called1.Store(true)
 		wg1.Done()
+		return nil
 	})
 
 	time.Sleep(3 * time.Second)
 
-	collector.Add(func(ctx context.Context) {
+	collector.Add(func(ctx context.Context) error {
 		called2.Store(true)
 		wg2.Done()
+		return nil
 	})
 
 	collector.Start(ctx)

--- a/counting/counting_test.go
+++ b/counting/counting_test.go
@@ -46,8 +46,10 @@ func TestCounterIncrement(t *testing.T) {
 	assert.True(t, updated)
 	assert.Equal(t, -1, value)
 
-	// Deletes in the database.
-	err = counter.Delete(ctx)
+	counterToDelete := NewEtcdCounter(etcdClient, key, 0)
+	// Deletes in the database using a different instance.
+	// It means the first instance will have a cache still.
+	err = counterToDelete.Delete(ctx)
 	assert.NoError(t, err)
 
 	// Counter deleted but the in-memory value continues.
@@ -98,8 +100,9 @@ func TestCounterDecrement(t *testing.T) {
 	assert.True(t, updated)
 	assert.Equal(t, -1, value)
 
-	// Deletes db record.
-	err = counter.Delete(ctx)
+	// Deletes db record with a different instance, to keep cache of previous instance.
+	counterToDelete := NewEtcdCounter(etcdClient, key, 5)
+	err = counterToDelete.Delete(ctx)
 	assert.NoError(t, err)
 
 	// Counter is deleted in db but the in-memory value continues.

--- a/locking/local_mutexer.go
+++ b/locking/local_mutexer.go
@@ -39,8 +39,9 @@ func (o *Mutexer) Get(key string) *sync.RWMutex {
 		m, ok = o.mutexes[key]
 		if !ok {
 			m = &sync.RWMutex{}
-			o.collector.Add(func(ctx context.Context) {
+			o.collector.Add(func(ctx context.Context) error {
 				o.Delete(key)
+				return nil
 			})
 			o.mutexes[key] = m
 			return m

--- a/locking/mutex_cache.go
+++ b/locking/mutex_cache.go
@@ -47,8 +47,9 @@ func (m *MutexStore) Get(key string) (DistributedMutex, error) {
 	if err != nil {
 		return nil, err
 	}
-	m.collector.Add(func(ctx context.Context) {
+	m.collector.Add(func(ctx context.Context) error {
 		m.Delete(key)
+		return nil
 	})
 	m.cache[key] = mutex
 	return mutex, nil

--- a/rhythm/spec_test.go
+++ b/rhythm/spec_test.go
@@ -198,6 +198,9 @@ func TestNextWithDelayedStart(t *testing.T) {
 		// Unsatisfiable
 		{"Mon Jul 9 23:35 2012", "Mon Jul 9 23:35 2012", "0 0 0 30 Feb ?", ""},
 		{"Mon Jul 9 23:35 2012", "Mon Jul 9 23:35 2012", "0 0 0 31 Apr ?", ""},
+
+		// Will never happen
+		{"Mon Jul 9 14:45 2024", "Mon Jan 1 00:00 0001", "0 0 0 30 Feb ?", "Mon Jan 1 00:00 0001"},
 	}
 
 	for _, c := range runs {


### PR DESCRIPTION
Fixes multiple races and bugs.

I validated that the garbage collection for jobs works. Once a job expires or repeat exceeds, then the counter is deleted.

It also fixes a bug where multiple overdue jobs trigger at the same second. We now drop overdue triggers.