### PR TITLE
internal/client: Delete keys in 128 key block transactions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: Test
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -14,21 +15,36 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver"
 )
 
-func Delete(client clientv3.KV, key string) error {
-	for {
-		ok, err := deleteOp(client, key)
-		if err != nil || ok {
-			return err
+func Delete(client clientv3.KV, keys ...string) error {
+	for i := 0; i < len(keys); i += 128 {
+		for {
+			ikeys := keys[i:min(len(keys), i+128)]
+			ok, err := deleteOp(client, ikeys...)
+			if err != nil {
+				return fmt.Errorf("failed to delete keys: %w", err)
+			}
+
+			if ok {
+				break
+			}
+
+			time.Sleep(time.Second)
 		}
-		time.Sleep(time.Second)
 	}
+
+	return nil
 }
 
-func deleteOp(client clientv3.KV, key string) (bool, error) {
+func deleteOp(client clientv3.KV, keys ...string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	_, err := client.Delete(ctx, key)
+	ops := make([]clientv3.Op, len(keys))
+	for i, key := range keys {
+		ops[i] = clientv3.OpDelete(key)
+	}
+
+	_, err := client.Txn(ctx).Then(ops...).Commit()
 	if err == nil {
 		return true, nil
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -21,16 +21,31 @@ import (
 type mock struct {
 	clientv3.KV
 	calls atomic.Int32
-	resp  *clientv3.DeleteResponse
 	err   error
 	lock  sync.Mutex
 }
 
-func (m *mock) Delete(context.Context, string, ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+func (m *mock) If(...clientv3.Cmp) clientv3.Txn {
+	return m
+}
+
+func (m *mock) Else(...clientv3.Op) clientv3.Txn {
+	return m
+}
+
+func (m *mock) Then(...clientv3.Op) clientv3.Txn {
+	return m
+}
+
+func (m *mock) Txn(context.Context) clientv3.Txn {
+	return m
+}
+
+func (m *mock) Commit() (*clientv3.TxnResponse, error) {
 	m.calls.Add(1)
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.resp, m.err
+	return nil, m.err
 }
 
 func Test_Delete(t *testing.T) {

--- a/internal/garbage/collector.go
+++ b/internal/garbage/collector.go
@@ -134,10 +134,13 @@ func (c *collector) collect() error {
 
 	c.log.Info("Collecting garbage", "keys", len(c.keys))
 
+	keyList := make([]string, 0, len(c.keys))
 	for key := range c.keys {
-		if err := client.Delete(c.client, key); err != nil {
-			return fmt.Errorf("failed to delete key %s: %w", key, err)
-		}
+		keyList = append(keyList, key)
+	}
+
+	if err := client.Delete(c.client, keyList...); err != nil {
+		return fmt.Errorf("failed to delete keys: %w", err)
 	}
 
 	c.log.Info("Garbage collection complete", "keys", len(c.keys))


### PR DESCRIPTION
Delete keys in 128 key block transactions to reduce the number of transactions required to delete all keys given to Delete. This is particularly useful for the counter garbage collector.