### PR TITLE
internal/leadership: inform lease key for deletion

### DIFF
--- a/internal/leadership/leadership.go
+++ b/internal/leadership/leadership.go
@@ -38,9 +38,10 @@ type Options struct {
 // partition, as well as ensuring that there are no other active partitions
 // which are acting on a different partition total.
 type Leadership struct {
-	log   logr.Logger
-	kv    clientv3.KV
-	lease clientv3.Lease
+	log     logr.Logger
+	kv      clientv3.KV
+	lease   clientv3.Lease
+	watcher clientv3.Watcher
 
 	partitionTotal string
 	key            *key.Key
@@ -54,6 +55,7 @@ func New(opts Options) *Leadership {
 		log:            opts.Log.WithName("leadership"),
 		kv:             opts.Client.KV,
 		lease:          opts.Client.Lease,
+		watcher:        opts.Client.Watcher,
 		partitionTotal: strconv.Itoa(int(opts.PartitionTotal)),
 		key:            opts.Key,
 		readyCh:        make(chan struct{}),
@@ -97,6 +99,15 @@ func (l *Leadership) Run(ctx context.Context) error {
 			// If not, create lease key.
 			// List lease namespace, ensure all values are the same as partitionTotal.
 
+			resp, err := l.kv.Get(ctx, l.key.LeaseKey())
+			if err != nil {
+				return err
+			}
+
+			watcherCtx, watcherCancel := context.WithCancel(ctx)
+			defer watcherCancel()
+			ch := l.watcher.Watch(watcherCtx, l.key.LeaseKey(), clientv3.WithRev(resp.Header.Revision))
+
 			for {
 				ok, err := l.attemptPartitionLeadership(ctx, lease.ID)
 				if err != nil {
@@ -105,6 +116,7 @@ func (l *Leadership) Run(ctx context.Context) error {
 
 				if ok {
 					l.log.Info("Partition leadership acquired")
+					watcherCancel()
 					break
 				}
 
@@ -113,7 +125,10 @@ func (l *Leadership) Run(ctx context.Context) error {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
-				case <-time.After(time.Second / 2):
+				case w := <-ch:
+					if err := w.Err(); err != nil {
+						return err
+					}
 				}
 			}
 

--- a/internal/leadership/leadership_test.go
+++ b/internal/leadership/leadership_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/diagridio/go-etcd-cron/internal/tests"
 )
 
+//nolint:gocyclo
 func Test_Run(t *testing.T) {
 	t.Parallel()
 
@@ -369,6 +370,78 @@ func Test_Run(t *testing.T) {
 		resp, err = client.Get(context.Background(), "abc/leases", clientv3.WithPrefix())
 		require.NoError(t, err)
 		require.Equal(t, int64(0), resp.Count)
+	})
+
+	t.Run("Two leaders of the same partition should make one passive unil the other is closed", func(t *testing.T) {
+		t.Parallel()
+
+		client := tests.EmbeddedETCD(t)
+		l1 := New(Options{
+			Client:         client,
+			PartitionTotal: 1,
+			Key: key.New(key.Options{
+				Namespace:   "abc",
+				PartitionID: 0,
+			}),
+		})
+		l2 := New(Options{
+			Client:         client,
+			PartitionTotal: 1,
+			Key: key.New(key.Options{
+				Namespace:   "abc",
+				PartitionID: 0,
+			}),
+		})
+
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		ctx2, cancel2 := context.WithCancel(context.Background())
+
+		errCh := make(chan error)
+
+		go func() { errCh <- l1.Run(ctx1) }()
+		require.NoError(t, l1.WaitForLeadership(ctx1))
+
+		resp, err := client.Leases(context.Background())
+		require.NoError(t, err)
+		assert.Len(t, resp.Leases, 1)
+
+		resp1, err := client.Get(context.Background(), "abc/leases/0")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), resp1.Count)
+		assert.Equal(t, []byte("1"), resp1.Kvs[0].Value)
+
+		go func() { errCh <- l2.Run(ctx2) }()
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			resp, err := client.Leases(context.Background())
+			require.NoError(t, err)
+			assert.Len(c, resp.Leases, 2)
+		}, time.Second*5, time.Millisecond*10)
+
+		cancel1()
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for error")
+		}
+
+		resp, err = client.Leases(context.Background())
+		require.NoError(t, err)
+		assert.Len(t, resp.Leases, 1)
+
+		require.NoError(t, l2.WaitForLeadership(ctx2))
+
+		resp2, err := client.Get(context.Background(), "abc/leases/0")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), resp2.Count)
+		assert.Equal(t, []byte("1"), resp2.Kvs[0].Value)
+
+		cancel2()
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for error")
+		}
 	})
 }
 


### PR DESCRIPTION
Use etcd watcher for waiting for the partitions lease key to become available, rather than checking every 1/2 seconds. This reduces load on etcd when multiple replicas with the same partition ID are running.

/assign @cicoyle 