### PR TITLE
ETCD Client: Retry all `too many requests` errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,3 +19,6 @@ linters:
  - gci
  - funlen
  - maintidx
+linters-settings:
+  goimports:
+    local-prefixes: github.com/diagridio

--- a/api.go
+++ b/api.go
@@ -11,8 +11,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/diagridio/go-etcd-cron/api"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/diagridio/go-etcd-cron/api"
 )
 
 // Add adds a new cron job to the cron instance.
@@ -44,7 +45,6 @@ func (c *cron) Add(ctx context.Context, name string, job *api.Job) error {
 	}
 
 	_, err = c.client.Put(ctx, c.key.JobKey(name), string(b))
-
 	return err
 }
 
@@ -94,10 +94,11 @@ func (c *cron) Delete(ctx context.Context, name string) error {
 		return err
 	}
 
-	qerr := c.queue.Dequeue(name)
-	_, err := c.client.Delete(ctx, c.key.JobKey(name))
+	if _, err := c.client.Delete(ctx, c.key.JobKey(name)); err != nil {
+		return err
+	}
 
-	return errors.Join(err, qerr)
+	return c.queue.Dequeue(name)
 }
 
 // validateName validates the name of a job.

--- a/api_test.go
+++ b/api_test.go
@@ -22,7 +22,7 @@ import (
 func Test_CRUD(t *testing.T) {
 	t.Parallel()
 
-	client := tests.EmbeddedETCD(t)
+	client := tests.EmbeddedETCDBareClient(t)
 	cron, err := New(Options{
 		Log:            logr.Discard(),
 		Client:         client,
@@ -97,7 +97,7 @@ func Test_Add(t *testing.T) {
 	t.Run("returns context error if cron not ready in time", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -118,7 +118,7 @@ func Test_Add(t *testing.T) {
 	t.Run("returns closed error if cron is closed", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -141,7 +141,7 @@ func Test_Add(t *testing.T) {
 	t.Run("invalid name should error", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -175,7 +175,7 @@ func Test_Add(t *testing.T) {
 	t.Run("empty job should error", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -211,7 +211,7 @@ func Test_Get(t *testing.T) {
 	t.Run("returns context error if cron not ready in time", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -232,7 +232,7 @@ func Test_Get(t *testing.T) {
 	t.Run("returns closed error if cron is closed", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -255,7 +255,7 @@ func Test_Get(t *testing.T) {
 	t.Run("invalid name should error", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -293,7 +293,7 @@ func Test_Delete(t *testing.T) {
 	t.Run("returns context error if cron not ready in time", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -312,7 +312,7 @@ func Test_Delete(t *testing.T) {
 	t.Run("returns closed error if cron is closed", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,
@@ -333,7 +333,7 @@ func Test_Delete(t *testing.T) {
 	t.Run("invalid name should error", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		cron, err := New(Options{
 			Log:            logr.Discard(),
 			Client:         client,

--- a/cron_test.go
+++ b/cron_test.go
@@ -29,7 +29,7 @@ import (
 func Test_retry(t *testing.T) {
 	t.Parallel()
 
-	client := tests.EmbeddedETCD(t)
+	client := tests.EmbeddedETCDBareClient(t)
 	var triggerd atomic.Int64
 	cron, err := New(Options{
 		Log:            logr.Discard(),
@@ -71,7 +71,7 @@ func Test_retry(t *testing.T) {
 func Test_payload(t *testing.T) {
 	t.Parallel()
 
-	client := tests.EmbeddedETCD(t)
+	client := tests.EmbeddedETCDBareClient(t)
 	gotCh := make(chan *api.TriggerRequest, 1)
 	cron, err := New(Options{
 		Log:            logr.Discard(),
@@ -129,7 +129,7 @@ func Test_payload(t *testing.T) {
 func Test_remove(t *testing.T) {
 	t.Parallel()
 
-	client := tests.EmbeddedETCD(t)
+	client := tests.EmbeddedETCDBareClient(t)
 	var triggered atomic.Int64
 	cron, err := New(Options{
 		Log:            logr.Discard(),
@@ -173,7 +173,7 @@ func Test_remove(t *testing.T) {
 func Test_upsert(t *testing.T) {
 	t.Parallel()
 
-	client := tests.EmbeddedETCD(t)
+	client := tests.EmbeddedETCDBareClient(t)
 	var triggered atomic.Int64
 	cron, err := New(Options{
 		Log:            logr.Discard(),
@@ -225,7 +225,7 @@ func Test_upsert(t *testing.T) {
 func Test_patition(t *testing.T) {
 	t.Parallel()
 
-	client := tests.EmbeddedETCD(t)
+	client := tests.EmbeddedETCDBareClient(t)
 	var triggered atomic.Int64
 
 	crons := make([]Interface, 100)
@@ -283,7 +283,7 @@ func Test_patition(t *testing.T) {
 func Test_oneshot(t *testing.T) {
 	t.Parallel()
 
-	client := tests.EmbeddedETCD(t)
+	client := tests.EmbeddedETCDBareClient(t)
 	var triggered atomic.Int64
 	cron, err := New(Options{
 		Log:            logr.Discard(),
@@ -331,7 +331,7 @@ func Test_oneshot(t *testing.T) {
 func Test_repeat(t *testing.T) {
 	t.Parallel()
 
-	client := tests.EmbeddedETCD(t)
+	client := tests.EmbeddedETCDBareClient(t)
 	var triggered atomic.Int64
 	cron, err := New(Options{
 		Log:            logr.Discard(),
@@ -383,7 +383,7 @@ func Test_Run(t *testing.T) {
 	t.Run("Running multiple times should error", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 		var triggered atomic.Int64
 		cronI, err := New(Options{
 			Log:            logr.Discard(),
@@ -440,7 +440,7 @@ func Test_schedule(t *testing.T) {
 	t.Run("if no counter, job should not be deleted", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 
 		now := time.Now().UTC().Add(time.Hour)
 		job := &api.JobStored{
@@ -509,7 +509,7 @@ func Test_schedule(t *testing.T) {
 	t.Run("if schedule is not done, job and counter should not be deleted", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 
 		now := time.Now().UTC().Add(time.Hour)
 		job := &api.JobStored{
@@ -588,7 +588,7 @@ func Test_schedule(t *testing.T) {
 	t.Run("if schedule is done, expect job and counter to be deleted", func(t *testing.T) {
 		t.Parallel()
 
-		client := tests.EmbeddedETCD(t)
+		client := tests.EmbeddedETCDBareClient(t)
 
 		now := time.Now().UTC()
 		job := &api.JobStored{

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,51 +7,108 @@ package client
 
 import (
 	"context"
-	"fmt"
-	"strings"
+	"errors"
 	"time"
 
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/etcdserver"
+	"k8s.io/utils/clock"
 )
 
-func Delete(client clientv3.KV, keys ...string) error {
+type Interface interface {
+	clientv3.Lease
+	clientv3.KV
+	clientv3.Watcher
+
+	DeleteMulti(keys ...string) error
+}
+
+type client struct {
+	*clientv3.Client
+	kv    clientv3.KV
+	clock clock.Clock
+}
+
+func New(cl *clientv3.Client) Interface {
+	var kv clientv3.KV
+	if cl != nil {
+		kv = cl.KV
+	}
+	return &client{
+		Client: cl,
+		kv:     kv,
+		clock:  clock.RealClock{},
+	}
+}
+
+func (c *client) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	return genericPP[string, string, clientv3.OpOption, clientv3.PutResponse](ctx, c, c.kv.Put, key, val, opts...)
+}
+
+func (c *client) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	return genericP[string, clientv3.OpOption, clientv3.GetResponse](ctx, c, c.kv.Get, key, opts...)
+}
+
+func (c *client) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+	return genericP[string, clientv3.OpOption, clientv3.DeleteResponse](ctx, c, c.kv.Delete, key, opts...)
+}
+
+func (c *client) DeleteMulti(keys ...string) error {
 	for i := 0; i < len(keys); i += 128 {
-		for {
-			ikeys := keys[i:min(len(keys), i+128)]
-			ok, err := deleteOp(client, ikeys...)
-			if err != nil {
-				return fmt.Errorf("failed to delete keys: %w", err)
-			}
+		batchI := min(128, len(keys)-i)
+		ops := make([]clientv3.Op, batchI)
+		for j := 0; j < batchI; j++ {
+			ops[j] = clientv3.OpDelete(keys[i+j])
+		}
 
-			if ok {
-				break
-			}
-
-			time.Sleep(time.Second)
+		err := generic(context.Background(), c, func(ctx context.Context) error {
+			_, terr := c.kv.Txn(ctx).Then(ops...).Commit()
+			return terr
+		})
+		if err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-func deleteOp(client clientv3.KV, keys ...string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
+type genericPPFunc[T any, K any, O any, R any] func(context.Context, T, K, ...O) (*R, error)
 
-	ops := make([]clientv3.Op, len(keys))
-	for i, key := range keys {
-		ops[i] = clientv3.OpDelete(key)
+func genericPP[T any, K any, O any, R any](ctx context.Context, c *client, op genericPPFunc[T, K, O, R], t T, k K, o ...O) (*R, error) {
+	var r *R
+	var err error
+	return r, generic(ctx, c, func(ctx context.Context) error {
+		r, err = op(ctx, t, k, o...)
+		return err
+	})
+}
+
+type genericPFunc[T any, O any, R any] func(context.Context, T, ...O) (*R, error)
+
+func genericP[T any, O any, R any](ctx context.Context, c *client, op genericPFunc[T, O, R], t T, o ...O) (*R, error) {
+	var r *R
+	var err error
+	return r, generic(ctx, c, func(ctx context.Context) error {
+		r, err = op(ctx, t, o...)
+		return err
+	})
+}
+
+func generic(ctx context.Context, c *client, op func(context.Context) error) error {
+	for {
+		ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		defer cancel()
+
+		err := op(ctx)
+		if err == nil {
+			return nil
+		}
+
+		if !errors.Is(err, rpctypes.ErrTooManyRequests) {
+			return err
+		}
+
+		<-c.clock.After(time.Second)
 	}
-
-	_, err := client.Txn(ctx).Then(ops...).Commit()
-	if err == nil {
-		return true, nil
-	}
-
-	if strings.HasSuffix(err.Error(), etcdserver.ErrTooManyRequests.Error()) {
-		return false, nil
-	}
-
-	return false, err
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -8,21 +8,21 @@ package client
 import (
 	"context"
 	"errors"
-	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/etcdserver"
+	clocktesting "k8s.io/utils/clock/testing"
 )
 
 type mock struct {
 	clientv3.KV
-	calls atomic.Int32
+	calls atomic.Uint32
 	err   error
-	lock  sync.Mutex
 }
 
 func (m *mock) If(...clientv3.Cmp) clientv3.Txn {
@@ -41,74 +41,127 @@ func (m *mock) Txn(context.Context) clientv3.Txn {
 	return m
 }
 
+func (m *mock) Put(context.Context, string, string, ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	m.calls.Add(1)
+	return nil, m.err
+}
+
+func (m *mock) Get(context.Context, string, ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	m.calls.Add(1)
+	return nil, m.err
+}
+
+func (m *mock) Delete(context.Context, string, ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+	m.calls.Add(1)
+	return nil, m.err
+}
+
 func (m *mock) Commit() (*clientv3.TxnResponse, error) {
 	m.calls.Add(1)
-	m.lock.Lock()
-	defer m.lock.Unlock()
 	return nil, m.err
 }
 
 func Test_Delete(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Successful delete should return nil", func(t *testing.T) {
-		t.Parallel()
+	tests := map[string]func(*client) error{
+		"Put": func(c *client) error {
+			_, err := c.Put(context.Background(), "123", "abc")
+			return err
+		},
+		"Get": func(c *client) error {
+			_, err := c.Get(context.Background(), "123")
+			return err
+		},
+		"Delete": func(c *client) error {
+			_, err := c.Delete(context.Background(), "123")
+			return err
+		},
+		"DeleteMulti": func(c *client) error {
+			return c.DeleteMulti("123")
+		},
+	}
 
-		kv := new(mock)
-		require.NoError(t, Delete(kv, "123"))
-		assert.Equal(t, int32(1), kv.calls.Load())
-	})
+	for name, test := range tests {
+		name, test := name, test
 
-	t.Run("Delete with error should return error", func(t *testing.T) {
-		t.Parallel()
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-		kv := new(mock)
-		kv.err = errors.New("this is an error")
-		require.Error(t, Delete(kv, "123"))
-		assert.Equal(t, int32(1), kv.calls.Load())
-	})
+			t.Run("Successful should return nil", func(t *testing.T) {
+				t.Parallel()
 
-	t.Run("Too many request errors should be retried until successful", func(t *testing.T) {
-		t.Parallel()
+				kv := new(mock)
+				require.NoError(t, test(&client{kv: kv}))
+				assert.Equal(t, uint32(1), kv.calls.Load())
+			})
 
-		kv := new(mock)
+			t.Run("With error should return error", func(t *testing.T) {
+				t.Parallel()
 
-		go func() {
-			for {
-				if kv.calls.Load() == 3 {
-					kv.lock.Lock()
-					kv.err = nil
-					kv.lock.Unlock()
+				kv := new(mock)
+				kv.err = errors.New("this is an error")
+				require.Error(t, test(&client{kv: kv}))
+				assert.Equal(t, uint32(1), kv.calls.Load())
+			})
 
-					break
-				}
-			}
-		}()
+			t.Run("Too many request errors should be retried until successful", func(t *testing.T) {
+				t.Parallel()
 
-		kv.err = etcdserver.ErrTooManyRequests
-		require.NoError(t, Delete(kv, "123"))
-		assert.GreaterOrEqual(t, kv.calls.Load(), int32(3))
-	})
+				clock := clocktesting.NewFakeClock(time.Now())
+				kv := &mock{err: rpctypes.ErrTooManyRequests}
+				errCh := make(chan error)
+				t.Cleanup(func() {
+					select {
+					case err := <-errCh:
+						require.NoError(t, err)
+					case <-time.After(time.Second):
+						assert.Fail(t, "timeout waiting for err")
+					}
+					assert.Equal(t, uint32(4), kv.calls.Load())
+				})
 
-	t.Run("Too many request errors should be retried until another error", func(t *testing.T) {
-		t.Parallel()
+				go func() {
+					errCh <- test(&client{kv: kv, clock: clock})
+				}()
 
-		kv := new(mock)
+				assert.Eventually(t, clock.HasWaiters, time.Second, time.Millisecond*10)
+				clock.Sleep(time.Second)
+				assert.Eventually(t, clock.HasWaiters, time.Second, time.Millisecond*10)
+				clock.Sleep(time.Second)
+				assert.Eventually(t, clock.HasWaiters, time.Second, time.Millisecond*10)
+				kv.err = nil
+				clock.Sleep(time.Second)
+			})
 
-		go func() {
-			for {
-				if kv.calls.Load() == 3 {
-					kv.lock.Lock()
-					kv.err = errors.New("this is an error")
-					kv.lock.Unlock()
+			t.Run("Too many request errors should be retried until another error", func(t *testing.T) {
+				t.Parallel()
 
-					break
-				}
-			}
-		}()
+				clock := clocktesting.NewFakeClock(time.Now())
+				kv := &mock{err: rpctypes.ErrTooManyRequests}
+				errCh := make(chan error)
+				t.Cleanup(func() {
+					select {
+					case err := <-errCh:
+						require.Error(t, err)
+					case <-time.After(time.Second):
+						assert.Fail(t, "timeout waiting for err")
+					}
+					assert.Equal(t, uint32(4), kv.calls.Load())
+				})
 
-		kv.err = etcdserver.ErrTooManyRequests
-		require.Error(t, Delete(kv, "123"))
-		assert.GreaterOrEqual(t, kv.calls.Load(), int32(3))
-	})
+				go func() {
+					errCh <- test(&client{kv: kv, clock: clock})
+				}()
+
+				assert.Eventually(t, clock.HasWaiters, time.Second, time.Millisecond*10)
+				clock.Sleep(time.Second)
+				assert.Eventually(t, clock.HasWaiters, time.Second, time.Millisecond*10)
+				clock.Sleep(time.Second)
+				assert.Eventually(t, clock.HasWaiters, time.Second, time.Millisecond*10)
+				kv.err = errors.New("this is an error")
+				clock.Sleep(time.Second)
+			})
+		})
+	}
 }

--- a/internal/garbage/collector.go
+++ b/internal/garbage/collector.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"k8s.io/utils/clock"
 
 	"github.com/diagridio/go-etcd-cron/internal/client"
@@ -26,7 +25,7 @@ type Options struct {
 	Log logr.Logger
 
 	// Client is the ETCD client to use for deleting keys.
-	Client clientv3.KV
+	Client client.Interface
 }
 
 // Interface is a garbage collector. It is used to queue-up deletion of ETCD
@@ -48,7 +47,7 @@ type Interface interface {
 // collector is the implementation of the garbage collector.
 type collector struct {
 	log          logr.Logger
-	client       clientv3.KV
+	client       client.Interface
 	clock        clock.Clock
 	keys         map[string]struct{}
 	soonerCh     chan struct{}
@@ -74,7 +73,6 @@ func New(opts Options) Interface {
 	}
 }
 
-//nolint:contextcheck
 func (c *collector) Run(ctx context.Context) error {
 	if !c.running.CompareAndSwap(false, true) {
 		return errors.New("garbage collector is already running")
@@ -139,7 +137,7 @@ func (c *collector) collect() error {
 		keyList = append(keyList, key)
 	}
 
-	if err := client.Delete(c.client, keyList...); err != nil {
+	if err := c.client.DeleteMulti(keyList...); err != nil {
 		return fmt.Errorf("failed to delete keys: %w", err)
 	}
 

--- a/internal/informer/informer.go
+++ b/internal/informer/informer.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/diagridio/go-etcd-cron/api"
+	"github.com/diagridio/go-etcd-cron/internal/client"
 	"github.com/diagridio/go-etcd-cron/internal/garbage"
 	"github.com/diagridio/go-etcd-cron/internal/grave"
 	"github.com/diagridio/go-etcd-cron/internal/key"
@@ -28,7 +29,7 @@ type Options struct {
 	Key *key.Key
 
 	// Client is the etcd client to use for storing cron entries.
-	Client *clientv3.Client
+	Client client.Interface
 
 	// Partitioner determines if a job belongs to this partition.
 	Partitioner partitioner.Interface
@@ -47,7 +48,7 @@ type Options struct {
 // for this partition.
 type Informer struct {
 	key       *key.Key
-	client    *clientv3.Client
+	client    client.Interface
 	part      partitioner.Interface
 	yard      *grave.Yard
 	collector garbage.Interface

--- a/internal/informer/syncer.go
+++ b/internal/informer/syncer.go
@@ -22,6 +22,8 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/mirror"
+
+	"github.com/diagridio/go-etcd-cron/internal/client"
 )
 
 const (
@@ -29,12 +31,12 @@ const (
 )
 
 // newSyncer creates a Syncer.
-func newSyncer(c *clientv3.Client, prefix string, rev int64) mirror.Syncer {
+func newSyncer(c client.Interface, prefix string, rev int64) mirror.Syncer {
 	return &syncer{c: c, prefix: prefix, rev: rev}
 }
 
 type syncer struct {
-	c      *clientv3.Client
+	c      client.Interface
 	rev    int64
 	prefix string
 }

--- a/internal/leadership/leadership_test.go
+++ b/internal/leadership/leadership_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"github.com/diagridio/go-etcd-cron/internal/client"
 	"github.com/diagridio/go-etcd-cron/internal/key"
 	"github.com/diagridio/go-etcd-cron/internal/tests"
 )
@@ -101,14 +102,14 @@ func Test_Run(t *testing.T) {
 
 		require.NoError(t, l.WaitForLeadership(context.Background()))
 
-		resp, err := client.KV.Get(ctx, "abc/leadership/0")
+		resp, err := client.Get(ctx, "abc/leadership/0")
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), resp.Count)
 		assert.Equal(t, []byte("10"), resp.Kvs[0].Value)
 		leaseID := resp.Kvs[0].Lease
 		assert.NotEqual(t, int64(0), leaseID)
 
-		lresp, err := client.Lease.Leases(ctx)
+		lresp, err := client.Leases(ctx)
 		require.NoError(t, err)
 		assert.Len(t, lresp.Leases, 1)
 		assert.Equal(t, leaseID, int64(lresp.Leases[0].ID))
@@ -120,12 +121,12 @@ func Test_Run(t *testing.T) {
 			t.Fatal("timed out waiting for error")
 		}
 
-		resp, err = client.KV.Get(context.Background(), "abc/leadership/0")
+		resp, err = client.Get(context.Background(), "abc/leadership/0")
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), resp.Count)
 		assert.Empty(t, resp.Kvs)
 
-		lresp, err = client.Lease.Leases(context.Background())
+		lresp, err = client.Leases(context.Background())
 		require.NoError(t, err)
 		assert.Empty(t, lresp.Leases)
 	})
@@ -143,9 +144,9 @@ func Test_Run(t *testing.T) {
 			}),
 		})
 
-		_, err := l.kv.Put(context.Background(), "abc/leadership/1", "10")
+		_, err := client.Put(context.Background(), "abc/leadership/1", "10")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/2", "10")
+		_, err = client.Put(context.Background(), "abc/leadership/2", "10")
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -154,14 +155,14 @@ func Test_Run(t *testing.T) {
 
 		require.NoError(t, l.WaitForLeadership(context.Background()))
 
-		resp, err := client.KV.Get(ctx, "abc/leadership/0")
+		resp, err := client.Get(ctx, "abc/leadership/0")
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), resp.Count)
 		assert.Equal(t, []byte("10"), resp.Kvs[0].Value)
 		leaseID := resp.Kvs[0].Lease
 		assert.NotEqual(t, int64(0), leaseID)
 
-		lresp, err := client.Lease.Leases(ctx)
+		lresp, err := client.Leases(ctx)
 		require.NoError(t, err)
 		assert.Len(t, lresp.Leases, 1)
 		assert.Equal(t, leaseID, int64(lresp.Leases[0].ID))
@@ -173,16 +174,16 @@ func Test_Run(t *testing.T) {
 			t.Fatal("timed out waiting for error")
 		}
 
-		resp, err = client.KV.Get(context.Background(), "abc/leadership/0")
+		resp, err = client.Get(context.Background(), "abc/leadership/0")
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), resp.Count)
 		assert.Empty(t, resp.Kvs)
 
-		lresp, err = client.Lease.Leases(context.Background())
+		lresp, err = client.Leases(context.Background())
 		require.NoError(t, err)
 		assert.Empty(t, lresp.Leases)
 
-		resp, err = client.KV.Get(context.Background(), "abc/leadership", clientv3.WithPrefix())
+		resp, err = client.Get(context.Background(), "abc/leadership", clientv3.WithPrefix())
 		require.NoError(t, err)
 		assert.Equal(t, int64(2), resp.Count)
 		require.Len(t, resp.Kvs, 2)
@@ -205,9 +206,9 @@ func Test_Run(t *testing.T) {
 			}),
 		})
 
-		_, err := l.kv.Put(context.Background(), "abc/leadership/0", "10")
+		_, err := client.Put(context.Background(), "abc/leadership/0", "10")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/2", "10")
+		_, err = client.Put(context.Background(), "abc/leadership/2", "10")
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -233,7 +234,7 @@ func Test_Run(t *testing.T) {
 			t.Fatal("expected WaitForLeadership to block")
 		}
 
-		_, err = l.kv.Delete(context.Background(), "abc/leadership/0")
+		_, err = client.Delete(context.Background(), "abc/leadership/0")
 		require.NoError(t, err)
 
 		select {
@@ -257,9 +258,9 @@ func Test_Run(t *testing.T) {
 			}),
 		})
 
-		_, err := l.kv.Put(context.Background(), "abc/leadership/2", "7")
+		_, err := client.Put(context.Background(), "abc/leadership/2", "7")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/8", "9")
+		_, err = client.Put(context.Background(), "abc/leadership/8", "9")
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -290,7 +291,7 @@ func Test_Run(t *testing.T) {
 		require.Equal(t, int64(1), resp.Count)
 		assert.Equal(t, []byte("10"), resp.Kvs[0].Value)
 
-		_, err = l.kv.Put(context.Background(), "abc/leadership/2", "10")
+		_, err = client.Put(context.Background(), "abc/leadership/2", "10")
 		require.NoError(t, err)
 
 		select {
@@ -299,7 +300,7 @@ func Test_Run(t *testing.T) {
 			t.Fatal("expected WaitForLeadership to block")
 		}
 
-		_, err = l.kv.Put(context.Background(), "abc/leadership/8", "10")
+		_, err = client.Put(context.Background(), "abc/leadership/8", "10")
 		require.NoError(t, err)
 
 		select {
@@ -405,7 +406,7 @@ func Test_Run(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, resp.Leases, 1)
 
-		resp1, err := client.Get(context.Background(), "abc/leases/0")
+		resp1, err := client.Get(context.Background(), "abc/leadership/0")
 		require.NoError(t, err)
 		require.Equal(t, int64(1), resp1.Count)
 		assert.Equal(t, []byte("1"), resp1.Kvs[0].Value)
@@ -431,7 +432,7 @@ func Test_Run(t *testing.T) {
 
 		require.NoError(t, l2.WaitForLeadership(ctx2))
 
-		resp2, err := client.Get(context.Background(), "abc/leases/0")
+		resp2, err := client.Get(context.Background(), "abc/leadership/0")
 		require.NoError(t, err)
 		require.Equal(t, int64(1), resp2.Count)
 		assert.Equal(t, []byte("1"), resp2.Kvs[0].Value)
@@ -480,7 +481,7 @@ func Test_checkLeadershipKeys(t *testing.T) {
 		})
 
 		for i := 0; i < 10; i++ {
-			_, err := l.kv.Put(context.Background(), "abc/leadership/"+strconv.Itoa(i), "10")
+			_, err := client.Put(context.Background(), "abc/leadership/"+strconv.Itoa(i), "10")
 			require.NoError(t, err)
 		}
 
@@ -502,11 +503,11 @@ func Test_checkLeadershipKeys(t *testing.T) {
 			}),
 		})
 
-		_, err := l.kv.Put(context.Background(), "abc/leadership/0", "10")
+		_, err := client.Put(context.Background(), "abc/leadership/0", "10")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/3", "10")
+		_, err = client.Put(context.Background(), "abc/leadership/3", "10")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/5", "10")
+		_, err = client.Put(context.Background(), "abc/leadership/5", "10")
 		require.NoError(t, err)
 
 		ok, err := l.checkLeadershipKeys(context.Background())
@@ -527,9 +528,9 @@ func Test_checkLeadershipKeys(t *testing.T) {
 			}),
 		})
 
-		_, err := l.kv.Put(context.Background(), "abc/leadership/3", "10")
+		_, err := client.Put(context.Background(), "abc/leadership/3", "10")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/5", "10")
+		_, err = client.Put(context.Background(), "abc/leadership/5", "10")
 		require.NoError(t, err)
 
 		ok, err := l.checkLeadershipKeys(context.Background())
@@ -550,13 +551,13 @@ func Test_checkLeadershipKeys(t *testing.T) {
 			}),
 		})
 
-		_, err := l.kv.Put(context.Background(), "abc/leadership/0", "10")
+		_, err := client.Put(context.Background(), "abc/leadership/0", "10")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/3", "5")
+		_, err = client.Put(context.Background(), "abc/leadership/3", "5")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/5", "10")
+		_, err = client.Put(context.Background(), "abc/leadership/5", "10")
 		require.NoError(t, err)
-		_, err = l.kv.Put(context.Background(), "abc/leadership/8", "8")
+		_, err = client.Put(context.Background(), "abc/leadership/8", "8")
 		require.NoError(t, err)
 
 		ok, err := l.checkLeadershipKeys(context.Background())
@@ -581,7 +582,7 @@ func Test_attemptPartitionLeadership(t *testing.T) {
 			}),
 		})
 
-		lease, err := l.lease.Grant(context.Background(), 20)
+		lease, err := client.Grant(context.Background(), 20)
 		require.NoError(t, err)
 
 		ok, err := l.attemptPartitionLeadership(context.Background(), lease.ID)
@@ -608,13 +609,13 @@ func Test_attemptPartitionLeadership(t *testing.T) {
 			}),
 		})
 
-		prevlease, err := l.lease.Grant(context.Background(), 20)
+		prevlease, err := client.Grant(context.Background(), 20)
 		require.NoError(t, err)
 
-		_, err = l.kv.Put(context.Background(), "abc/leadership/0", "10", clientv3.WithLease(prevlease.ID))
+		_, err = client.Put(context.Background(), "abc/leadership/0", "10", clientv3.WithLease(prevlease.ID))
 		require.NoError(t, err)
 
-		lease, err := l.lease.Grant(context.Background(), 20)
+		lease, err := client.Grant(context.Background(), 20)
 		require.NoError(t, err)
 
 		ok, err := l.attemptPartitionLeadership(context.Background(), lease.ID)
@@ -637,7 +638,7 @@ func Test_WaitForLeadership(t *testing.T) {
 		t.Parallel()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		leadership := New(Options{Client: new(clientv3.Client)})
+		leadership := New(Options{Client: client.New(nil)})
 		cancel()
 		assert.Equal(t, context.Canceled, leadership.WaitForLeadership(ctx))
 	})
@@ -647,7 +648,7 @@ func Test_WaitForLeadership(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		leadership := New(Options{Client: new(clientv3.Client)})
+		leadership := New(Options{Client: client.New(nil)})
 		close(leadership.readyCh)
 		require.NoError(t, leadership.WaitForLeadership(ctx))
 	})


### PR DESCRIPTION
Update internal/client to be a generic wrapper around a real etcd client. This internal client will retry `too many requests` errors until successful, the given context is canceled, or an error occurs.