### PR TITLE
fix panic

### DIFF
--- a/internal/scheduler/builder.go
+++ b/internal/scheduler/builder.go
@@ -35,7 +35,7 @@ func NewBuilder() *Builder {
 
 // Scheduler returns the scheduler based on the given stored job.
 func (b *Builder) Scheduler(job *api.JobStored) (Interface, error) {
-	if job.GetJob().Schedule == nil {
+	if job.GetJob().GetSchedule() == "" {
 		return &oneshot{
 			dueTime: job.GetDueTime().AsTime(),
 		}, nil


### PR DESCRIPTION
I'm seeing a panic upon scheduler startup where I had jobs in etcd that needed to trigger still, but were not in the queue bc it was starting up and the job field was nil so it was panic-ing on the `.Schedule` line