### PR TITLE
Fix memory leak in queuelock

### DIFF
--- a/api.go
+++ b/api.go
@@ -98,10 +98,14 @@ func (c *cron) Delete(ctx context.Context, name string) error {
 	jobKey := c.key.JobKey(name)
 
 	c.queueLock.Lock(jobKey)
-	defer c.queueLock.Unlock(jobKey)
+	defer c.queueLock.DeleteUnlock(jobKey)
 
 	if _, err := c.client.Delete(ctx, jobKey); err != nil {
 		return err
+	}
+
+	if _, ok := c.queueCache.Load(jobKey); !ok {
+		return nil
 	}
 
 	c.queueCache.Delete(jobKey)


### PR DESCRIPTION
Fix memory leak in queue lock whereby deleting jobs on schedulers which do not host the job will grow the queue lock indefinitely.