### PR TITLE
Support space characters (" ") in Job names

### DIFF
--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -493,6 +493,46 @@ func Test_schedule(t *testing.T) {
 	})
 }
 
+func Test_jobWithSpace(t *testing.T) {
+	t.Parallel()
+
+	cron := testCronWithOptions(t, testCronOptions{
+		total:  1,
+		client: tests.EmbeddedETCDBareClient(t),
+	})
+
+	require.NoError(t, cron.api.Add(context.Background(), "hello world", &api.Job{
+		DueTime: ptr.Of(time.Now().Add(2).Format(time.RFC3339)),
+	}))
+	resp, err := cron.api.Get(context.Background(), "hello world")
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), cron.triggered.Load())
+		resp, err = cron.api.Get(context.Background(), "hello world")
+		assert.NoError(c, err)
+		assert.Nil(c, resp)
+	}, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, cron.api.Add(context.Background(), "another hello world", &api.Job{
+		Schedule: ptr.Of("@every 1s"),
+	}))
+	resp, err = cron.api.Get(context.Background(), "another hello world")
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	listresp, err := cron.api.List(context.Background(), "")
+	assert.NoError(t, err)
+	assert.Len(t, listresp.Jobs, 1)
+	require.NoError(t, cron.api.Delete(context.Background(), "another hello world"))
+	resp, err = cron.api.Get(context.Background(), "another hello world")
+	assert.NoError(t, err)
+	assert.Nil(t, resp)
+	listresp, err = cron.api.List(context.Background(), "")
+	assert.NoError(t, err)
+	assert.Empty(t, listresp.Jobs)
+}
+
 type testCronOptions struct {
 	total     uint32
 	gotCh     chan *api.TriggerRequest

--- a/internal/api/validator/validator.go
+++ b/internal/api/validator/validator.go
@@ -28,7 +28,7 @@ type Validator struct {
 func New(opts Options) *Validator {
 	jobNameSanitizer := opts.JobNameSanitizer
 	if jobNameSanitizer == nil {
-		jobNameSanitizer = strings.NewReplacer("_", "", ":", "", "-", "")
+		jobNameSanitizer = strings.NewReplacer("_", "", ":", "", "-", "", " ", "")
 	}
 	return &Validator{
 		jobNameSanitizer: jobNameSanitizer,

--- a/internal/api/validator/validator_test.go
+++ b/internal/api/validator/validator_test.go
@@ -94,6 +94,10 @@ func Test_JobName(t *testing.T) {
 			name:   "aABVCD||dapr-::123:123||dapr.internal.dapr-tests.perf-workflowsapp.workflow||24b3fbad-0db5-4e81-a272-71f6018a66a6||start-4NYDFil-",
 			expErr: false,
 		},
+		{
+			name:   "aABVCD||dapr-::123:123||dapr.internal.dapr-tests.perf-  workflowsapp.workflow||24b3fbad-0db5-4e81        -a272-71f6018a66a6||start-4NYDFil-",
+			expErr: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Now that keys correctly use `path.Join` concatenation to the Job name, we can safely add support for space characters.

Closes https://github.com/diagridio/go-etcd-cron/issues/46