### PR TITLE
Push collector on same parition & ignore context DeadlineExceeded

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -74,7 +75,7 @@ func (c *client) DeleteMulti(keys ...string) error {
 			return terr
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to delete keys (%d): %w", len(ops), err)
 		}
 	}
 

--- a/internal/garbage/collector.go
+++ b/internal/garbage/collector.go
@@ -151,7 +151,7 @@ func (c *collector) collect() error {
 	}
 
 	if err := c.client.DeleteMulti(keyList...); err != nil {
-		return fmt.Errorf("failed to delete keys: %w", err)
+		return fmt.Errorf("failed to delete garbage counters (%d): %w", len(keyList), err)
 	}
 
 	c.log.Info("Garbage collection complete", "keys", len(c.keys))

--- a/internal/informer/informer.go
+++ b/internal/informer/informer.go
@@ -160,9 +160,6 @@ func (i *Informer) handleEvent(ev *clientv3.Event) (*Event, error) {
 		if i.yard.HasJustDeleted(string(ev.PrevKv.Key)) {
 			return nil, nil
 		}
-		if ev.Kv != nil {
-			i.collector.Push(i.key.CounterKey(i.key.JobName(ev.Kv.Key)))
-		}
 
 		kv = ev.PrevKv
 	default:
@@ -176,6 +173,10 @@ func (i *Informer) handleEvent(ev *clientv3.Event) (*Event, error) {
 
 	if !i.part.IsJobManaged(job.GetPartitionId()) {
 		return nil, nil
+	}
+
+	if !isPut && ev.Kv != nil {
+		i.collector.Push(i.key.CounterKey(i.key.JobName(ev.Kv.Key)))
 	}
 
 	return &Event{

--- a/internal/leadership/leadership.go
+++ b/internal/leadership/leadership.go
@@ -89,6 +89,9 @@ func (l *Leadership) Run(ctx context.Context) error {
 			defer cancel()
 			//nolint:contextcheck
 			_, err = l.client.Revoke(rctx, lease.ID)
+			if errors.Is(err, context.DeadlineExceeded) {
+				return nil
+			}
 			return err
 		},
 		func(ctx context.Context) error {


### PR DESCRIPTION
Update the informer to not push deleted keys to the collector if the key is not the same partition as the replica.

Ignore context DeadlineExceeded errors on the Leadsership Revoke client so `Run` doesn't return context errors on shutdown.