### PR TITLE
Counter: ensure job name set on existing counter

### DIFF
--- a/internal/counter/counter.go
+++ b/internal/counter/counter.go
@@ -88,23 +88,24 @@ func New(ctx context.Context, opts Options) (Interface, bool, error) {
 		return nil, false, err
 	}
 
+	c := &counter{
+		name:       opts.Name,
+		counterKey: counterKey,
+		jobKey:     jobKey,
+		client:     opts.Client,
+		schedule:   opts.Schedule,
+		job:        opts.Job,
+		yard:       opts.Yard,
+		collector:  opts.Collector,
+		triggerRequest: &api.TriggerRequest{
+			Name:     opts.Name,
+			Metadata: opts.Job.GetJob().GetMetadata(),
+			Payload:  opts.Job.GetJob().GetPayload(),
+		},
+	}
+
 	if res.Count == 0 {
-		c := &counter{
-			name:       opts.Name,
-			jobKey:     jobKey,
-			counterKey: counterKey,
-			client:     opts.Client,
-			schedule:   opts.Schedule,
-			job:        opts.Job,
-			count:      &stored.Counter{JobPartitionId: opts.Job.GetPartitionId()},
-			yard:       opts.Yard,
-			collector:  opts.Collector,
-			triggerRequest: &api.TriggerRequest{
-				Name:     opts.Name,
-				Metadata: opts.Job.GetJob().GetMetadata(),
-				Payload:  opts.Job.GetJob().GetPayload(),
-			},
-		}
+		c.count = &stored.Counter{JobPartitionId: opts.Job.GetPartitionId()}
 
 		if ok, err := c.tickNext(); err != nil || !ok {
 			return nil, false, err
@@ -131,21 +132,7 @@ func New(ctx context.Context, opts Options) (Interface, bool, error) {
 		}
 	}
 
-	c := &counter{
-		counterKey: counterKey,
-		jobKey:     jobKey,
-		client:     opts.Client,
-		schedule:   opts.Schedule,
-		job:        opts.Job,
-		count:      count,
-		yard:       opts.Yard,
-		collector:  opts.Collector,
-		triggerRequest: &api.TriggerRequest{
-			Name:     opts.Name,
-			Metadata: opts.Job.GetJob().GetMetadata(),
-			Payload:  opts.Job.GetJob().GetPayload(),
-		},
-	}
+	c.count = count
 
 	if ok, err := c.tickNext(); err != nil || !ok {
 		return nil, false, err

--- a/internal/counter/counter_test.go
+++ b/internal/counter/counter_test.go
@@ -167,6 +167,8 @@ func Test_New(t *testing.T) {
 		assert.True(t, ok)
 		assert.NotNil(t, c)
 
+		assert.Equal(t, "1", c.JobName())
+
 		cancel()
 		select {
 		case err := <-errCh:


### PR DESCRIPTION
Ensure counter has the job name set when the counter already exists and is loaded from etcd.