### PR TITLE
API engine retry

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,6 +26,10 @@ import (
 	"github.com/diagridio/go-etcd-cron/internal/scheduler"
 )
 
+var (
+	ErrClosed = errors.New("api is closed")
+)
+
 type Options struct {
 	Log              logr.Logger
 	Client           client.Interface
@@ -277,7 +281,7 @@ func (a *api) DeliverablePrefixes(ctx context.Context, prefixes ...string) (cont
 func (a *api) waitReady(ctx context.Context) error {
 	select {
 	case <-a.closeCh:
-		return errors.New("api is closed")
+		return ErrClosed
 	case <-a.readyCh:
 		return nil
 	case <-ctx.Done():

--- a/internal/engine/fake/fake.go
+++ b/internal/engine/fake/fake.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2024 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/diagridio/go-etcd-cron/internal/api"
+)
+
+type Fake struct {
+	runFn func(context.Context) error
+	apiFn func() api.Interface
+}
+
+func New() *Fake {
+	return &Fake{
+		runFn: func(context.Context) error {
+			return nil
+		},
+		apiFn: func() api.Interface {
+			return nil
+		},
+	}
+}
+
+func (f *Fake) WithRun(fn func(context.Context) error) *Fake {
+	f.runFn = fn
+	return f
+}
+
+func (f *Fake) WithAPI(a api.Interface) *Fake {
+	f.apiFn = func() api.Interface { return a }
+
+	return f
+}
+
+func (f *Fake) Run(ctx context.Context) error {
+	return f.runFn(ctx)
+}
+
+func (f *Fake) API() api.Interface {
+	return f.apiFn()
+}

--- a/internal/engine/fake/fake_test.go
+++ b/internal/engine/fake/fake_test.go
@@ -1,0 +1,16 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package fake
+
+import (
+	"testing"
+
+	"github.com/diagridio/go-etcd-cron/internal/engine"
+)
+
+func Test_Fake(t *testing.T) {
+	var _ engine.Interface = New()
+}

--- a/internal/engine/retry/retry.go
+++ b/internal/engine/retry/retry.go
@@ -1,0 +1,145 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/diagridio/go-etcd-cron/api"
+	internalapi "github.com/diagridio/go-etcd-cron/internal/api"
+	"github.com/diagridio/go-etcd-cron/internal/engine"
+)
+
+var errClosed = errors.New("cron is closed")
+
+// Retry is a engine wrapper for executing the cron API, which will retry calls
+// when the API is "closing". This ensures that caller API calls will be held
+// and eventually executed during leadership reshuffles.
+type Retry struct {
+	engine atomic.Pointer[engine.Interface]
+
+	lock    sync.Mutex
+	readyCh chan struct{}
+	closeCh chan struct{}
+}
+
+func New() *Retry {
+	return &Retry{
+		readyCh: make(chan struct{}),
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (r *Retry) Add(ctx context.Context, name string, job *api.Job) error {
+	return r.handle(ctx, func(a internalapi.Interface) error {
+		return a.Add(ctx, name, job)
+	})
+}
+
+func (r *Retry) Get(ctx context.Context, name string) (*api.Job, error) {
+	var job *api.Job
+	var err error
+	err = r.handle(ctx, func(a internalapi.Interface) error {
+		job, err = a.Get(ctx, name)
+		return err
+	})
+	return job, err
+}
+
+func (r *Retry) Delete(ctx context.Context, name string) error {
+	return r.handle(ctx, func(a internalapi.Interface) error {
+		return a.Delete(ctx, name)
+	})
+}
+
+func (r *Retry) DeletePrefixes(ctx context.Context, prefixes ...string) error {
+	return r.handle(ctx, func(a internalapi.Interface) error {
+		return a.DeletePrefixes(ctx, prefixes...)
+	})
+}
+
+func (r *Retry) List(ctx context.Context, prefix string) (*api.ListResponse, error) {
+	var resp *api.ListResponse
+	var err error
+	err = r.handle(ctx, func(a internalapi.Interface) error {
+		resp, err = a.List(ctx, prefix)
+		return err
+	})
+	return resp, err
+}
+
+func (r *Retry) DeliverablePrefixes(ctx context.Context, prefixes ...string) (context.CancelFunc, error) {
+	var cancel context.CancelFunc
+	var err error
+	err = r.handle(ctx, func(a internalapi.Interface) error {
+		cancel, err = a.DeliverablePrefixes(ctx, prefixes...)
+		return err
+	})
+	return cancel, err
+}
+
+func (r *Retry) handle(ctx context.Context, fn func(internalapi.Interface) error) error {
+	for {
+		a, err := r.waitAPIReady(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = fn(a)
+		if err == nil || !errors.Is(err, internalapi.ErrClosed) {
+			return err
+		}
+
+		select {
+		case <-time.After(time.Millisecond * 300):
+		case <-r.closeCh:
+			return errClosed
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// Ready unblocks the Retry API calls, allowing them to be executed on the
+// underlying engine.
+func (r *Retry) Ready(engine engine.Interface) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.engine.Store(&engine)
+	close(r.readyCh)
+}
+
+// NotReady blocks the Retry API calls, preventing them from being executed
+// on the underlying engine.
+func (r *Retry) NotReady() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.readyCh = make(chan struct{})
+}
+
+func (r *Retry) Close() {
+	close(r.closeCh)
+}
+
+func (r *Retry) waitAPIReady(ctx context.Context) (internalapi.Interface, error) {
+	r.lock.Lock()
+	readyCh := r.readyCh
+	r.lock.Unlock()
+
+	select {
+	case <-readyCh:
+		return (*r.engine.Load()).API(), nil
+	case <-r.closeCh:
+		return nil, errClosed
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/internal/engine/retry/retry_test.go
+++ b/internal/engine/retry/retry_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/diagridio/go-etcd-cron/internal/api"
+	"github.com/diagridio/go-etcd-cron/internal/engine/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_handle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("if the given context is cancelled, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		r := New()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.Error(t, r.handle(ctx, nil))
+	})
+
+	t.Run("if retry has been closed, then should return error", func(t *testing.T) {
+		t.Parallel()
+
+		r := New()
+		r.Close()
+		require.Error(t, r.handle(context.Background(), nil))
+	})
+
+	t.Run("when retry ready, should call given func", func(t *testing.T) {
+		t.Parallel()
+
+		r := New()
+		r.Ready(fake.New())
+
+		var called atomic.Bool
+		require.NoError(t, r.handle(context.Background(), func(a api.Interface) error {
+			called.Store(true)
+			return nil
+		}))
+
+		assert.True(t, called.Load())
+	})
+
+	t.Run("if handle func returns error, expect error", func(t *testing.T) {
+		t.Parallel()
+
+		r := New()
+		r.Ready(fake.New())
+
+		var called atomic.Bool
+		require.Error(t, r.handle(context.Background(), func(a api.Interface) error {
+			called.Store(true)
+			return errors.New("this is an error")
+		}))
+
+		assert.True(t, called.Load())
+	})
+
+	t.Run("if error api closed, expect multiple calls till it is not", func(t *testing.T) {
+		t.Parallel()
+
+		r := New()
+		r.Ready(fake.New())
+
+		var called atomic.Int64
+		require.NoError(t, r.handle(context.Background(), func(a api.Interface) error {
+			if called.Add(1) < 4 {
+				return api.ErrClosed
+			}
+			return nil
+		}))
+
+		assert.Equal(t, int64(4), called.Load())
+	})
+
+	t.Run("if context cancelled during retry loop, expect context error", func(t *testing.T) {
+		t.Parallel()
+
+		r := New()
+		r.Ready(fake.New())
+
+		var called atomic.Int64
+		ctx, cancel := context.WithCancel(context.Background())
+		err := r.handle(ctx, func(a api.Interface) error {
+			if called.Add(1) > 3 {
+				cancel()
+			}
+			return api.ErrClosed
+		})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("if closed during retry loop, expect closed error", func(t *testing.T) {
+		t.Parallel()
+
+		r := New()
+		r.Ready(fake.New())
+
+		var called atomic.Int64
+		err := r.handle(context.Background(), func(a api.Interface) error {
+			if called.Add(1) > 3 {
+				r.Close()
+			}
+			return api.ErrClosed
+		})
+		require.ErrorIs(t, err, errClosed)
+	})
+}


### PR DESCRIPTION
Adds a engine API retry which will continue to retry an API call if the API currently reports that the API is closed. This is useful for when leadership changes are in progress (typical during boot where leaders are actively being shuffled). The retry will continue to retry an active API call every 300ms when the API reports as closed (because leadership has caused the API to be closed). The retry will continue to cancel calls if the caller has cancelled the context, or if the cron is shutting down.