### PR TITLE
Schedule: support Second precision as adverted

### DIFF
--- a/internal/engine/retry/retry.go
+++ b/internal/engine/retry/retry.go
@@ -50,7 +50,10 @@ func (r *Retry) Get(ctx context.Context, name string) (*api.Job, error) {
 		job, err = a.Get(ctx, name)
 		return err
 	})
-	return job, err
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
 }
 
 func (r *Retry) Delete(ctx context.Context, name string) error {
@@ -72,7 +75,10 @@ func (r *Retry) List(ctx context.Context, prefix string) (*api.ListResponse, err
 		resp, err = a.List(ctx, prefix)
 		return err
 	})
-	return resp, err
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (r *Retry) DeliverablePrefixes(ctx context.Context, prefixes ...string) (context.CancelFunc, error) {
@@ -82,7 +88,10 @@ func (r *Retry) DeliverablePrefixes(ctx context.Context, prefixes ...string) (co
 		cancel, err = a.DeliverablePrefixes(ctx, prefixes...)
 		return err
 	})
-	return cancel, err
+	if err != nil {
+		return nil, err
+	}
+	return cancel, nil
 }
 
 func (r *Retry) handle(ctx context.Context, fn func(internalapi.Interface) error) error {

--- a/internal/scheduler/builder.go
+++ b/internal/scheduler/builder.go
@@ -26,12 +26,24 @@ type Builder struct {
 	// clock is the clock used to get the current time. Used for manipulating
 	// time in tests.
 	clock clock.Clock
+
+	// parser parses job schedules.
+	parser cron.Parser
 }
 
 // NewBuilder creates a new scheduler builder.
 func NewBuilder() *Builder {
 	return &Builder{
 		clock: clock.RealClock{},
+		parser: cron.NewParser(
+			cron.Second |
+				cron.Minute |
+				cron.Hour |
+				cron.Dom |
+				cron.Month |
+				cron.Dow |
+				cron.Descriptor,
+		),
 	}
 }
 
@@ -43,7 +55,8 @@ func (b *Builder) Schedule(job *stored.Job) (Interface, error) {
 		}, nil
 	}
 
-	cronSched, err := cron.ParseStandard(job.GetJob().GetSchedule())
+	cronSched, err := b.parser.Parse(job.GetJob().GetSchedule())
+	//cronSched, err := cron.ParseStandard(job.GetJob().GetSchedule())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates the schedule API to support seconds precision, as is advertised.