### PR TITLE
Fix upsert of Jobs on cluster

### DIFF
--- a/internal/informer/informer.go
+++ b/internal/informer/informer.go
@@ -172,7 +172,11 @@ func (i *Informer) handleEvent(ev *clientv3.Event) (*Event, error) {
 	}
 
 	if !i.part.IsJobManaged(job.GetPartitionId()) {
-		return nil, nil
+		return &Event{
+			IsPut: false,
+			Key:   kv.Key,
+			Job:   nil,
+		}, nil
 	}
 
 	if !isPut && ev.Kv != nil {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -162,8 +162,11 @@ func (q *Queue) HandleInformerEvent(ctx context.Context, e *informer.Event) erro
 	}
 
 	if _, ok := q.counterCache.LoadAndDelete(string(e.Key)); ok {
-		q.collector.Push(q.key.CounterKey(jobName))
 		q.queue.Dequeue(string(e.Key))
+
+		if e.Job != nil {
+			q.collector.Push(q.key.CounterKey(jobName))
+		}
 	}
 
 	return nil

--- a/tests/suite/upsert_test.go
+++ b/tests/suite/upsert_test.go
@@ -40,3 +40,28 @@ func Test_upsert(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, resp.Kvs)
 }
+
+func Test_upsert_duetime(t *testing.T) {
+	t.Parallel()
+
+	cron := integration.NewBase(t, 3)
+
+	job := &api.Job{
+		DueTime:  ptr.Of("1s"),
+		Schedule: ptr.Of("@every 5s"),
+	}
+	now := time.Now().Format(time.RFC3339)
+	require.NoError(t, cron.API().Add(cron.Context(), now, job))
+
+	time.Sleep(time.Second * 2)
+	assert.Equal(t, 1, cron.Triggered())
+
+	job = &api.Job{
+		DueTime:  ptr.Of("20s"),
+		Schedule: ptr.Of("@every 5s"),
+	}
+	require.NoError(t, cron.API().Add(cron.Context(), now, job))
+
+	time.Sleep(time.Second * 5)
+	assert.Equal(t, 1, cron.Triggered())
+}


### PR DESCRIPTION
An upsert of a Job will produce a Job whose partition will likely put the job on another replica when running as a cluster. Previously, if a job was not partitioned for that replica, the informer would always drop this update event, meaning that the job would not be deleted from the queue on the previously active replica.

Special case put events to always delete the job on the current replica if the job it put, and the partition does not match.