### PR TITLE
Leadership: re-reconcile on failed key read

### DIFF
--- a/internal/leadership/elector/elector.go
+++ b/internal/leadership/elector/elector.go
@@ -128,7 +128,11 @@ func (e *Elector) Elect(ctx context.Context) (context.Context, *Elected, error) 
 	for {
 		ldata, ok, err = e.quorumReconcile(ctx, resp)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to reconcile to leadership quorum: %w", err)
+			e.log.Error(err, "failed to reconcile to leadership quorum")
+		}
+
+		if ctx.Err() != nil {
+			return nil, nil, err
 		}
 
 		if ok {
@@ -191,7 +195,11 @@ func (e *Elector) Reelect(ctx context.Context) (context.Context, *Elected, error
 	for {
 		ldata, ok, err = e.quorumReconcile(ctx, resp)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to reconcile to leadership quorum: %w", err)
+			e.log.Error(err, "failed to reconcile to leadership quorum")
+		}
+
+		if ctx.Err() != nil {
+			return nil, nil, err
 		}
 
 		if ok {


### PR DESCRIPTION
In the event of failed reading of other leadership keys, the leader will continue to wait for the next informer reconcile instead of hard erroring out.

This is useful for events whereby the leadership key space values are not readable because they have been written by another cron who has a different value API.