### PR TITLE
Scheduler Builder: Use correct parser for next calculation

### DIFF
--- a/internal/scheduler/builder.go
+++ b/internal/scheduler/builder.go
@@ -7,6 +7,7 @@ package scheduler
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -35,14 +36,13 @@ type Builder struct {
 func NewBuilder() *Builder {
 	return &Builder{
 		clock: clock.RealClock{},
-		parser: cron.NewParser(
-			cron.Second |
-				cron.Minute |
-				cron.Hour |
-				cron.Dom |
-				cron.Month |
-				cron.Dow |
-				cron.Descriptor,
+		parser: cron.NewParser(cron.Second |
+			cron.Minute |
+			cron.Hour |
+			cron.Dom |
+			cron.Month |
+			cron.Dow |
+			cron.Descriptor,
 		),
 	}
 }
@@ -56,9 +56,8 @@ func (b *Builder) Schedule(job *stored.Job) (Interface, error) {
 	}
 
 	cronSched, err := b.parser.Parse(job.GetJob().GetSchedule())
-	//cronSched, err := cron.ParseStandard(job.GetJob().GetSchedule())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(">>ERROR HERE: %w", err)
 	}
 
 	//nolint:protogetter
@@ -97,9 +96,9 @@ func (b *Builder) Parse(job *api.Job) (*stored.Job, error) {
 	}
 
 	if job.Schedule != nil {
-		_, err := cron.ParseStandard(job.GetSchedule())
+		_, err := b.parser.Parse(job.GetSchedule())
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf(">>HERE2: %w", err)
 		}
 	}
 

--- a/internal/scheduler/builder_test.go
+++ b/internal/scheduler/builder_test.go
@@ -27,9 +27,7 @@ func Test_Schedule(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	clock := clocktesting.NewFakeClock(now)
 
-	cronSched, err := cron.ParseStandard("@every 1h")
-	require.NoError(t, err)
-	cronSched2, err := cron.NewParser(
+	parser := cron.NewParser(
 		cron.Second |
 			cron.Minute |
 			cron.Hour |
@@ -37,7 +35,11 @@ func Test_Schedule(t *testing.T) {
 			cron.Month |
 			cron.Dow |
 			cron.Descriptor,
-	).Parse("1 2 3 4 5 6")
+	)
+
+	cronSched, err := parser.Parse("@every 1h")
+	require.NoError(t, err)
+	cronSched2, err := parser.Parse("1 2 3 4 5 6")
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -412,7 +414,8 @@ func Test_Parse(t *testing.T) {
 		testInLoop := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			builder := &Builder{clock: clock}
+			builder := NewBuilder()
+			builder.clock = clock
 			gotStored, gotErr := builder.Parse(testInLoop.job)
 			if gotStored != nil {
 				assert.NotEqual(t, uint32(0), gotStored.GetPartitionId())

--- a/tests/suite/schedule_test.go
+++ b/tests/suite/schedule_test.go
@@ -189,3 +189,15 @@ func Test_schedule(t *testing.T) {
 		assert.Equal(t, 0, cron.Triggered())
 	})
 }
+
+func Test_schedule_six(t *testing.T) {
+	t.Parallel()
+
+	cron := integration.NewBase(t, 1)
+
+	job := &api.Job{
+		Schedule: ptr.Of("1 2 3 4 5 6"),
+	}
+
+	require.NoError(t, cron.API().Add(cron.Context(), "def", job))
+}


### PR DESCRIPTION
Update scheduler builder to use the correct parser so that 6 column cron style schedule strings are accepted.

Adds integration test for API.