### PR TITLE
Prevent panic where elector is nil on shutdown

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -154,7 +154,7 @@ func (c *cron) Run(ctx context.Context) error {
 		leadership.Run,
 		func(ctx context.Context) error {
 			ectx, elected, err := leadership.Elect(ctx)
-			if err != nil {
+			if err != nil || elected == nil {
 				return err
 			}
 


### PR DESCRIPTION
If election is attempted during shutdown (context cancelled), then the election will abort and a nil elector will be returned with a nil error. In this case, check if elector is nil return nil in the concurrency manager to prevent panic.