### PR TITLE
Retry: retry handle functions upon receiving transient etcd errors

### DIFF
--- a/internal/engine/retry/retry.go
+++ b/internal/engine/retry/retry.go
@@ -136,6 +136,12 @@ func (r *Retry) handleShouldRetry(err error) bool {
 		return true
 	case errors.Is(err, etcdserver.ErrTimeoutWaitAppliedIndex):
 		return true
+	case errors.Is(err, etcdserver.ErrLeaderChanged):
+		return true
+	case errors.Is(err, etcdserver.ErrNotEnoughStartedMembers):
+		return true
+	case errors.Is(err, etcdserver.ErrTooManyRequests):
+		return true
 	default:
 		return false
 	}

--- a/internal/engine/retry/retry.go
+++ b/internal/engine/retry/retry.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.etcd.io/etcd/server/v3/etcdserver"
+
 	"github.com/diagridio/go-etcd-cron/api"
 	internalapi "github.com/diagridio/go-etcd-cron/internal/api"
 	"github.com/diagridio/go-etcd-cron/internal/engine"
@@ -102,7 +104,7 @@ func (r *Retry) handle(ctx context.Context, fn func(internalapi.Interface) error
 		}
 
 		err = fn(a)
-		if err == nil || !errors.Is(err, internalapi.ErrClosed) {
+		if !r.handleShouldRetry(err) {
 			return err
 		}
 
@@ -113,6 +115,29 @@ func (r *Retry) handle(ctx context.Context, fn func(internalapi.Interface) error
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+	}
+}
+
+// handleShouldRetry returns true if the error returned from the handle
+// function should be retried.
+func (r *Retry) handleShouldRetry(err error) bool {
+	switch {
+	case err == nil:
+		return false
+	case errors.Is(err, internalapi.ErrClosed):
+		return true
+	case errors.Is(err, etcdserver.ErrTimeout):
+		return true
+	case errors.Is(err, etcdserver.ErrTimeoutDueToLeaderFail):
+		return true
+	case errors.Is(err, etcdserver.ErrTimeoutDueToConnectionLost):
+		return true
+	case errors.Is(err, etcdserver.ErrTimeoutLeaderTransfer):
+		return true
+	case errors.Is(err, etcdserver.ErrTimeoutWaitAppliedIndex):
+		return true
+	default:
+		return false
 	}
 }
 

--- a/tests/suite/midtrigger_test.go
+++ b/tests/suite/midtrigger_test.go
@@ -61,7 +61,7 @@ func Test_midtrigger(t *testing.T) {
 	releaseCh <- struct{}{}
 
 	select {
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 10):
 		require.Fail(t, "timed out waiting for trigger")
 	case got := <-gotCh:
 		assert.True(t, proto.Equal(p2, got))


### PR DESCRIPTION
Update the engine retry to retry transient etcd errors;

```go
ErrTimeout                       = errors.New("etcdserver: request timed out")
ErrTimeoutDueToLeaderFail        = errors.New("etcdserver: request timed out, possibly due to previous leader failure")
ErrTimeoutDueToConnectionLost    = errors.New("etcdserver: request timed out, possibly due to connection lost")
ErrTimeoutLeaderTransfer         = errors.New("etcdserver: request timed out, leader transfer took too long")
ErrTimeoutWaitAppliedIndex       = errors.New("etcdserver: request timed out, waiting for the applied index took too long")
```