### PR TITLE
Staging Queue: Return deliverable on context cancel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/diagridio/go-etcd-cron
 go 1.23.1
 
 require (
-	github.com/dapr/kit v0.13.1-0.20241015130326-866002abe68a
+	github.com/dapr/kit v0.15.1
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/dapr/kit v0.13.1-0.20241015130326-866002abe68a h1:3+EDN84/gtelE14Ka3TW8pP52vC8QdSHKeNIe3JpsYU=
-github.com/dapr/kit v0.13.1-0.20241015130326-866002abe68a/go.mod h1:Hz1W2LmWfA4UX/12MdA+brsf+np6f/1dJt6C6F63cjI=
+github.com/dapr/kit v0.15.1 h1:WInC8IBveslveCBE2DDeaXh62Si4Wr2Fdv2yJ/7hrDQ=
+github.com/dapr/kit v0.15.1/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -275,7 +275,7 @@ func (a *api) DeliverablePrefixes(ctx context.Context, prefixes ...string) (cont
 		return nil, errors.New("no prefixes provided")
 	}
 
-	return a.queue.DeliverablePrefixes(prefixes...), nil
+	return a.queue.DeliverablePrefixes(ctx, prefixes...)
 }
 
 func (a *api) waitReady(ctx context.Context) error {

--- a/internal/queue/staging.go
+++ b/internal/queue/staging.go
@@ -19,8 +19,11 @@ import (
 // longer be delivered. Multiple of the same prefix can be added and are
 // tracked as a pool, meaning the prefix is still active if at least one
 // instance is still registered.
-func (q *Queue) DeliverablePrefixes(prefixes ...string) context.CancelFunc {
-	q.eventsLock.Lock()
+func (q *Queue) DeliverablePrefixes(ctx context.Context, prefixes ...string) (context.CancelFunc, error) {
+	// Attempt lock until context cancel.
+	if err := q.eventsLock.Lock(ctx); err != nil {
+		return nil, err
+	}
 	defer q.eventsLock.Unlock()
 
 	var toEnqueue []counter.Interface
@@ -44,7 +47,7 @@ func (q *Queue) DeliverablePrefixes(prefixes ...string) context.CancelFunc {
 	}
 
 	return func() {
-		q.eventsLock.Lock()
+		q.eventsLock.Lock(context.Background())
 		defer q.eventsLock.Unlock()
 
 		for _, prefix := range prefixes {
@@ -54,7 +57,7 @@ func (q *Queue) DeliverablePrefixes(prefixes ...string) context.CancelFunc {
 				}
 			}
 		}
-	}
+	}, nil
 }
 
 // stage adds the counter (job) to the staging queue. Accounting for race
@@ -62,7 +65,8 @@ func (q *Queue) DeliverablePrefixes(prefixes ...string) context.CancelFunc {
 // on the current deliverable prefixes and should be immediately re-queued at
 // the current count.
 func (q *Queue) stage(counter counter.Interface) bool {
-	q.eventsLock.Lock()
+	// Must lock.
+	q.eventsLock.Lock(context.Background())
 	defer q.eventsLock.Unlock()
 
 	jobName := counter.JobName()

--- a/internal/queue/staging_test.go
+++ b/internal/queue/staging_test.go
@@ -6,14 +6,15 @@ Licensed under the MIT License.
 package queue
 
 import (
-	"sync"
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/dapr/kit/concurrency/fifo"
+	"github.com/dapr/kit/concurrency/lock"
 	"github.com/dapr/kit/events/queue"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/diagridio/go-etcd-cron/internal/counter"
 	"github.com/diagridio/go-etcd-cron/internal/counter/fake"
@@ -27,11 +28,12 @@ func Test_DeliverablePrefixes(t *testing.T) {
 
 		q := &Queue{
 			deliverablePrefixes: make(map[string]*atomic.Int32),
-			eventsLock:          fifo.New(),
+			eventsLock:          lock.NewContext(),
 		}
 		assert.Empty(t, q.deliverablePrefixes)
 
-		cancel := q.DeliverablePrefixes()
+		cancel, err := q.DeliverablePrefixes(context.Background())
+		require.NoError(t, err)
 		assert.Empty(t, q.deliverablePrefixes)
 		cancel()
 		assert.Empty(t, q.deliverablePrefixes)
@@ -42,11 +44,12 @@ func Test_DeliverablePrefixes(t *testing.T) {
 
 		q := &Queue{
 			deliverablePrefixes: make(map[string]*atomic.Int32),
-			eventsLock:          fifo.New(),
+			eventsLock:          lock.NewContext(),
 		}
 		assert.Empty(t, q.deliverablePrefixes)
 
-		cancel := q.DeliverablePrefixes("abc")
+		cancel, err := q.DeliverablePrefixes(context.Background(), "abc")
+		require.NoError(t, err)
 		assert.Len(t, q.deliverablePrefixes, 1)
 		cancel()
 		assert.Empty(t, q.deliverablePrefixes)
@@ -57,13 +60,15 @@ func Test_DeliverablePrefixes(t *testing.T) {
 
 		q := &Queue{
 			deliverablePrefixes: make(map[string]*atomic.Int32),
-			eventsLock:          fifo.New(),
+			eventsLock:          lock.NewContext(),
 		}
 		assert.Empty(t, q.deliverablePrefixes)
 
-		cancel1 := q.DeliverablePrefixes("abc")
+		cancel1, err := q.DeliverablePrefixes(context.Background(), "abc")
+		require.NoError(t, err)
 		assert.Len(t, q.deliverablePrefixes, 1)
-		cancel2 := q.DeliverablePrefixes("abc")
+		cancel2, err := q.DeliverablePrefixes(context.Background(), "abc")
+		require.NoError(t, err)
 		assert.Len(t, q.deliverablePrefixes, 1)
 
 		cancel1()
@@ -77,17 +82,21 @@ func Test_DeliverablePrefixes(t *testing.T) {
 
 		q := &Queue{
 			deliverablePrefixes: make(map[string]*atomic.Int32),
-			eventsLock:          fifo.New(),
+			eventsLock:          lock.NewContext(),
 		}
 		assert.Empty(t, q.deliverablePrefixes)
 
-		cancel1 := q.DeliverablePrefixes("abc")
+		cancel1, err := q.DeliverablePrefixes(context.Background(), "abc")
+		require.NoError(t, err)
 		assert.Len(t, q.deliverablePrefixes, 1)
-		cancel2 := q.DeliverablePrefixes("abc")
+		cancel2, err := q.DeliverablePrefixes(context.Background(), "abc")
+		require.NoError(t, err)
 		assert.Len(t, q.deliverablePrefixes, 1)
-		cancel3 := q.DeliverablePrefixes("def")
+		cancel3, err := q.DeliverablePrefixes(context.Background(), "def")
+		require.NoError(t, err)
 		assert.Len(t, q.deliverablePrefixes, 2)
-		cancel4 := q.DeliverablePrefixes("def")
+		cancel4, err := q.DeliverablePrefixes(context.Background(), "def")
+		require.NoError(t, err)
 		assert.Len(t, q.deliverablePrefixes, 2)
 
 		cancel1()
@@ -103,15 +112,15 @@ func Test_DeliverablePrefixes(t *testing.T) {
 	t.Run("staged counters should be enqueued if they match an added prefix", func(t *testing.T) {
 		t.Parallel()
 
-		var lock sync.Mutex
+		lock := lock.NewContext()
 		var triggered []string
 		q := &Queue{
 			deliverablePrefixes: make(map[string]*atomic.Int32),
-			eventsLock:          fifo.New(),
+			eventsLock:          lock,
 			staged:              make(map[string]counter.Interface),
 			queue: queue.NewProcessor[string, counter.Interface](
 				func(counter counter.Interface) {
-					lock.Lock()
+					lock.Lock(context.Background())
 					defer lock.Unlock()
 					triggered = append(triggered, counter.JobName())
 				},
@@ -130,20 +139,22 @@ func Test_DeliverablePrefixes(t *testing.T) {
 			"xyz123": counter5, "xyz234": counter6,
 		}
 
-		cancel := q.DeliverablePrefixes("abc", "xyz")
+		cancel, err := q.DeliverablePrefixes(context.Background(), "abc", "xyz")
+		require.NoError(t, err)
 		t.Cleanup(cancel)
 		assert.Equal(t, map[string]counter.Interface{"def123": counter3, "def234": counter4}, q.staged)
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			lock.Lock()
+			lock.Lock(context.Background())
 			defer lock.Unlock()
 			assert.ElementsMatch(c, []string{"abc123", "abc234", "xyz123", "xyz234"}, triggered)
 		}, time.Second*10, time.Millisecond*10)
 
-		cancel = q.DeliverablePrefixes("d")
+		cancel, err = q.DeliverablePrefixes(context.Background(), "d")
+		require.NoError(t, err)
 		t.Cleanup(cancel)
 		assert.Empty(t, q.staged)
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			lock.Lock()
+			lock.Lock(context.Background())
 			defer lock.Unlock()
 			assert.ElementsMatch(c, []string{"abc123", "abc234", "xyz123", "xyz234", "def123", "def234"}, triggered)
 		}, time.Second*10, time.Millisecond*10)
@@ -196,7 +207,7 @@ func Test_stage(t *testing.T) {
 
 			q := &Queue{
 				deliverablePrefixes: make(map[string]*atomic.Int32),
-				eventsLock:          fifo.New(),
+				eventsLock:          lock.NewContext(),
 				staged:              make(map[string]counter.Interface),
 			}
 


### PR DESCRIPTION
Update the events lock of the queue to use a Context lock. Updates the DeliverablePrefix func to return an error when the, now given, context is cancelled whilst waiting for a lock.

Updates dapr/kit to use v0.15.1 to use this queue.