### PR TITLE
API: Adds `AddIfNotExists`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ func main() {
   meta, _ := anypb.New(wrapperspb.String("world"))
   tt := time.Now().Add(time.Second).Format(time.RFC3339)
 
-  err = cron.Add(context.TODO(), "my-job", &api.Job{
+  err = cron.AddIfNotExists(context.TODO(), "my-job", &api.Job{
     DueTime:  &tt,
     Payload:  payload,
     Metadata: meta,

--- a/api/api.go
+++ b/api/api.go
@@ -31,6 +31,10 @@ type Interface interface {
 	// Add adds a job to the cron instance.
 	Add(ctx context.Context, name string, job *Job) error
 
+	// AddIfNotExists adds a job to the cron instance. If the Job already exists,
+	// then returns an error.
+	AddIfNotExists(ctx context.Context, name string, job *Job) error
+
 	// Get gets a job from the cron instance.
 	Get(ctx context.Context, name string) (*Job, error)
 

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package errors
+
+import "fmt"
+
+// JobAlreadyExists is an error type that indicates a Job already exists in the
+// store.
+type JobAlreadyExists struct {
+	err string
+}
+
+func (j JobAlreadyExists) Error() string {
+	return j.err
+}
+
+func NewJobAlreadyExists(job string) JobAlreadyExists {
+	return JobAlreadyExists{err: fmt.Sprintf("job already exists: '%s'", job)}
+}
+
+func IsJobAlreadyExists(err error) bool {
+	_, ok := err.(JobAlreadyExists)
+	return ok
+}

--- a/api/errors/errors_test.go
+++ b/api/errors/errors_test.go
@@ -1,0 +1,12 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package errors
+
+import "testing"
+
+func Test_JobAlreadyExists(t *testing.T) {
+	var _ error = NewJobAlreadyExists("")
+}

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -190,6 +190,13 @@ func (c *cron) Add(ctx context.Context, name string, job *api.Job) error {
 	return c.api.Add(ctx, name, job)
 }
 
+// AddIfNotExists forwards the call to the embedded API. If the Job already
+// exists, then an error is returned.
+// Error can be checked against `JobAlreadyExists` in `/api/errors/exists`.
+func (c *cron) AddIfNotExists(ctx context.Context, name string, job *api.Job) error {
+	return c.api.AddIfNotExists(ctx, name, job)
+}
+
 // Get forwards the call to the embedded API.
 func (c *cron) Get(ctx context.Context, name string) (*api.Job, error) {
 	return c.api.Get(ctx, name)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/diagridio/go-etcd-cron/internal/client/fake"
 )
 
-func Test_Delete(t *testing.T) {
+func Test_CRUD(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]func(*client) error{
@@ -37,6 +37,10 @@ func Test_Delete(t *testing.T) {
 		},
 		"DeleteMulti": func(c *client) error {
 			return c.DeleteMulti("123")
+		},
+		"PutIfNotExists": func(c *client) error {
+			_, err := c.PutIfNotExists(context.Background(), "123", "abc")
+			return err
 		},
 	}
 

--- a/internal/client/errors/errors.go
+++ b/internal/client/errors/errors.go
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2024 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package errors
+
+// KeyAlreadyExists is an error type that indicates a key already exists in the
+// store.
+type KeyAlreadyExists struct {
+	key string
+}
+
+func (k KeyAlreadyExists) Error() string {
+	return k.key
+}
+
+func NewKeyAlreadyExists(key string) KeyAlreadyExists {
+	return KeyAlreadyExists{key}
+}
+
+func IsKeyAlreadyExists(err error) bool {
+	_, ok := err.(KeyAlreadyExists)
+	return ok
+}

--- a/internal/client/errors/errors_test.go
+++ b/internal/client/errors/errors_test.go
@@ -1,0 +1,12 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package errors
+
+import "testing"
+
+func Test_KeyAlreadyExists(t *testing.T) {
+	var _ error = NewKeyAlreadyExists("")
+}

--- a/tests/framework/fake/fake.go
+++ b/tests/framework/fake/fake.go
@@ -22,6 +22,8 @@ type Fake struct {
 	isElectedFn func() bool
 
 	deliverablePrefixesFn func(ctx context.Context, prefixes ...string) (context.CancelFunc, error)
+
+	addIfNotExistsFn func(ctx context.Context, name string, job *api.Job) error
 }
 
 func New() *Fake {
@@ -47,6 +49,9 @@ func New() *Fake {
 		},
 		deliverablePrefixesFn: func(context.Context, ...string) (context.CancelFunc, error) {
 			return func() {}, nil
+		},
+		addIfNotExistsFn: func(context.Context, string, *api.Job) error {
+			return nil
 		},
 		isElectedFn: func() bool {
 			return false
@@ -94,6 +99,11 @@ func (f *Fake) WithIsElected(fn func() bool) *Fake {
 	return f
 }
 
+func (f *Fake) WithAddIfNotExists(fn func(context.Context, string, *api.Job) error) *Fake {
+	f.addIfNotExistsFn = fn
+	return f
+}
+
 func (f *Fake) Run(ctx context.Context) error {
 	return f.runFn(ctx)
 }
@@ -124,4 +134,8 @@ func (f *Fake) DeliverablePrefixes(ctx context.Context, prefixes ...string) (con
 
 func (f *Fake) IsElected() bool {
 	return f.isElectedFn()
+}
+
+func (f *Fake) AddIfNotExists(ctx context.Context, name string, job *api.Job) error {
+	return f.addIfNotExistsFn(ctx, name, job)
 }

--- a/tests/suite/upsert_test.go
+++ b/tests/suite/upsert_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/diagridio/go-etcd-cron/api"
+	"github.com/diagridio/go-etcd-cron/api/errors"
 	"github.com/diagridio/go-etcd-cron/tests/framework/cron/integration"
 )
 
@@ -51,6 +52,66 @@ func Test_upsert_duetime(t *testing.T) {
 		Schedule: ptr.Of("@every 5s"),
 	}
 	now := time.Now().Format(time.RFC3339)
+	require.NoError(t, cron.API().Add(cron.Context(), now, job))
+
+	time.Sleep(time.Second * 2)
+	assert.Equal(t, 1, cron.Triggered())
+
+	job = &api.Job{
+		DueTime:  ptr.Of("20s"),
+		Schedule: ptr.Of("@every 5s"),
+	}
+	require.NoError(t, cron.API().Add(cron.Context(), now, job))
+
+	time.Sleep(time.Second * 5)
+	assert.Equal(t, 1, cron.Triggered())
+}
+
+func Test_upsert_ifnotexists(t *testing.T) {
+	t.Parallel()
+
+	cron := integration.NewBase(t, 1)
+
+	job := &api.Job{
+		DueTime: ptr.Of(time.Now().Add(time.Hour).Format(time.RFC3339)),
+	}
+
+	require.NoError(t, cron.API().AddIfNotExists(cron.Context(), "def", job))
+	err := cron.API().AddIfNotExists(cron.Context(), "def", job)
+	require.Error(t, err)
+	assert.True(t, errors.IsJobAlreadyExists(err))
+	assert.Equal(t, "job already exists: 'def'", err.Error())
+	require.NoError(t, cron.API().Add(cron.Context(), "def", job))
+
+	job = &api.Job{
+		DueTime: ptr.Of(time.Now().Add(time.Second).Format(time.RFC3339)),
+	}
+	require.NoError(t, cron.API().Add(cron.Context(), "def", job))
+
+	assert.Eventually(t, func() bool {
+		return cron.Triggered() == 1
+	}, 5*time.Second, 1*time.Second)
+
+	resp, err := cron.Client().Get(context.Background(), "abc/jobs/def")
+	require.NoError(t, err)
+	assert.Empty(t, resp.Kvs)
+}
+
+func Test_upsert_duetime_ifnotexists(t *testing.T) {
+	t.Parallel()
+
+	cron := integration.NewBase(t, 3)
+
+	job := &api.Job{
+		DueTime:  ptr.Of("1s"),
+		Schedule: ptr.Of("@every 5s"),
+	}
+	now := time.Now().Format(time.RFC3339)
+
+	require.NoError(t, cron.API().AddIfNotExists(cron.Context(), now, job))
+	err := cron.API().AddIfNotExists(cron.Context(), now, job)
+	require.Error(t, err)
+	assert.True(t, errors.IsJobAlreadyExists(err))
 	require.NoError(t, cron.API().Add(cron.Context(), now, job))
 
 	time.Sleep(time.Second * 2)


### PR DESCRIPTION
Adds a new `AddIfNotExists` method to the API and client. This method will add a new Job only if the job does not already exist. If the job does exist, it returns a new typed error `JobAlreadyExists` in `/api/errors`.