### PR TITLE
Adds counters loop & counter cache

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -304,7 +304,7 @@ func (a *api) DeliverablePrefixes(ctx context.Context, prefixes ...string) (cont
 		return nil, errors.New("no prefixes provided")
 	}
 
-	return a.queue.DeliverablePrefixes(prefixes...), nil
+	return a.queue.DeliverablePrefixes(ctx, prefixes...)
 }
 
 func (a *api) waitReady(ctx context.Context) error {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -117,7 +117,7 @@ func (e *engine) Run(ctx context.Context) error {
 				case <-ctx.Done():
 					return nil
 				case event := <-ev:
-					e.queue.Inform(event)
+					e.queue.Inform(ctx, event)
 				}
 			}
 		},

--- a/internal/informer/informer.go
+++ b/internal/informer/informer.go
@@ -139,6 +139,9 @@ func (i *Informer) handleEvent(ev *clientv3.Event) (*queue.Informed, error) {
 		return nil, fmt.Errorf("failed to unmarshal job: %w", err)
 	}
 
+	// TODO: @joshvanl: remove the need to serialize the job name here- we should
+	// attempt to only serialize the job name on `Get` etc. API calls, since this
+	// uses a large number of allocations.
 	jobName := i.key.JobName(ev.Kv.Key)
 	if !i.part.IsJobManaged(job.GetPartitionId()) {
 		return &queue.Informed{

--- a/internal/queue/loops/control/control.go
+++ b/internal/queue/loops/control/control.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dapr/kit/ptr"
-
 	"github.com/diagridio/go-etcd-cron/internal/api/queue"
 	"github.com/diagridio/go-etcd-cron/internal/queue/actioner"
 	"github.com/diagridio/go-etcd-cron/internal/queue/loops"
@@ -30,13 +28,10 @@ type control struct {
 }
 
 func New(opts Options) loops.Interface[*queue.ControlEvent] {
-	return loops.New(loops.Options[*queue.ControlEvent]{
-		Handler: &control{
-			jobs: opts.Jobs,
-			act:  opts.Actioner,
-		},
-		BufferSize: ptr.Of(uint64(1024)),
-	})
+	return loops.New(&control{
+		jobs: opts.Jobs,
+		act:  opts.Actioner,
+	}, 1024)
 }
 
 func (c *control) Handle(_ context.Context, event *queue.ControlEvent) error {

--- a/internal/queue/loops/counters/counters_test.go
+++ b/internal/queue/loops/counters/counters_test.go
@@ -313,6 +313,7 @@ func Test_counters(t *testing.T) {
 
 		var called int
 		c := &counters{
+			idx: new(atomic.Int64),
 			cancel: func() {
 				called++
 			},

--- a/internal/queue/loops/fake/fake.go
+++ b/internal/queue/loops/fake/fake.go
@@ -7,6 +7,8 @@ package fake
 
 import (
 	"context"
+
+	"github.com/diagridio/go-etcd-cron/internal/queue/loops"
 )
 
 type Fake[T any] struct {
@@ -48,4 +50,8 @@ func (f *Fake[T]) Enqueue(t T) {
 
 func (f *Fake[T]) Close(t T) {
 	f.closeFn(t)
+}
+
+func (f *Fake[T]) Reset(loops.Handler[T], uint64) loops.Interface[T] {
+	return f
 }

--- a/internal/queue/loops/router/router_test.go
+++ b/internal/queue/loops/router/router_test.go
@@ -66,7 +66,9 @@ func Test_router(t *testing.T) {
 		var called int
 		loop := fake.New[*queue.JobAction]().WithClose(func(action *queue.JobAction) {
 			assert.Equal(t, &queue.JobAction{
-				Action: new(queue.JobAction_Close),
+				Action: &queue.JobAction_Close{
+					Close: new(queue.Close),
+				},
 			}, action)
 			called++
 		})


### PR DESCRIPTION
Adds a counters loop & counter cache via a sync.Pool to reduce memory allocations. The loop struct and counter struct will be created O(millions) of times during the life cycle of a cron instance. Reusing struct memory improves performance.

We should replace the current loop queue channel, with a ring buffer to prevent allocating the channel every time.