### PR TITLE
queue: Fix go routine leak in router

### DIFF
--- a/internal/queue/loops/router/router.go
+++ b/internal/queue/loops/router/router.go
@@ -75,6 +75,12 @@ func (r *router) handleEvent(ctx context.Context, event *queue.JobEvent) error {
 	// If the counter doesn't exist yet, create.
 	counter, ok := r.counters[jobName]
 	if !ok {
+		// If we are being informed of a counter which has already been removed
+		// from the store, ignore.
+		if i := event.Action.GetInformed(); i != nil && !i.IsPut {
+			return nil
+		}
+
 		counter = r.newCounter(ctx, jobName)
 	}
 

--- a/internal/queue/loops/router/router_test.go
+++ b/internal/queue/loops/router/router_test.go
@@ -169,7 +169,7 @@ func Test_router(t *testing.T) {
 		exp := &queue.JobAction{Action: &queue.JobAction_Informed{
 			Informed: &queue.Informed{
 				Name:  "test-job",
-				IsPut: false,
+				IsPut: true,
 			},
 		}}
 
@@ -186,5 +186,30 @@ func Test_router(t *testing.T) {
 		}))
 
 		assert.Len(t, r.counters, 2)
+	})
+
+	t.Run("if handle event for delete with non-existing counter, expect no create or enqueue", func(t *testing.T) {
+		t.Parallel()
+
+		exp := &queue.JobAction{Action: &queue.JobAction_Informed{
+			Informed: &queue.Informed{
+				Name:  "test-job",
+				IsPut: false,
+			},
+		}}
+
+		r := &router{
+			act: actionerfake.New(),
+			counters: map[string]*counter{
+				"test-job-2": &counter{},
+			},
+		}
+
+		require.NoError(t, r.Handle(t.Context(), &queue.JobEvent{
+			JobName: "test-job",
+			Action:  exp,
+		}))
+
+		assert.Len(t, r.counters, 1)
 	})
 }

--- a/tests/suite/goleak_test.go
+++ b/tests/suite/goleak_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2024 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package suite
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dapr/kit/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/diagridio/go-etcd-cron/api"
+	"github.com/diagridio/go-etcd-cron/tests/framework/cron/integration"
+)
+
+// Test cannot be done in parallel to ensure runtime go routines are correct.
+func Test_goleak(t *testing.T) {
+	cron := integration.NewBase(t, 1)
+
+	startGoN := runtime.NumGoroutine()
+
+	const n = 10000
+	for i := range n {
+		require.NoError(t, cron.API().Add(cron.Context(), strconv.Itoa(i), &api.Job{
+			DueTime: ptr.Of("0s"),
+		}))
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, n, cron.Triggered())
+	}, 10*time.Second, time.Millisecond*10)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.InDelta(c, startGoN, runtime.NumGoroutine(), 10)
+	}, 10*time.Second, time.Millisecond*10)
+}

--- a/tests/suite/upsert_test.go
+++ b/tests/suite/upsert_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dapr/kit/ptr"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -51,8 +52,8 @@ func Test_upsert_duetime(t *testing.T) {
 		DueTime:  ptr.Of("1s"),
 		Schedule: ptr.Of("@every 5s"),
 	}
-	now := time.Now().Format(time.RFC3339)
-	require.NoError(t, cron.API().Add(cron.Context(), now, job))
+	name := uuid.NewString()
+	require.NoError(t, cron.API().Add(cron.Context(), name, job))
 
 	time.Sleep(time.Second * 2)
 	assert.Equal(t, 1, cron.Triggered())
@@ -61,7 +62,7 @@ func Test_upsert_duetime(t *testing.T) {
 		DueTime:  ptr.Of("20s"),
 		Schedule: ptr.Of("@every 5s"),
 	}
-	require.NoError(t, cron.API().Add(cron.Context(), now, job))
+	require.NoError(t, cron.API().Add(cron.Context(), name, job))
 
 	time.Sleep(time.Second * 5)
 	assert.Equal(t, 1, cron.Triggered())
@@ -138,13 +139,13 @@ func Test_upsert_duetime_ifnotexists(t *testing.T) {
 		DueTime:  ptr.Of("1s"),
 		Schedule: ptr.Of("@every 5s"),
 	}
-	now := time.Now().Format(time.RFC3339)
+	name := uuid.NewString()
 
-	require.NoError(t, cron.API().AddIfNotExists(cron.Context(), now, job))
-	err := cron.API().AddIfNotExists(cron.Context(), now, job)
+	require.NoError(t, cron.API().AddIfNotExists(cron.Context(), name, job))
+	err := cron.API().AddIfNotExists(cron.Context(), name, job)
 	require.Error(t, err)
 	assert.True(t, errors.IsJobAlreadyExists(err))
-	require.NoError(t, cron.API().Add(cron.Context(), now, job))
+	require.NoError(t, cron.API().Add(cron.Context(), name, job))
 
 	time.Sleep(time.Second * 2)
 	assert.Equal(t, 1, cron.Triggered())
@@ -153,7 +154,7 @@ func Test_upsert_duetime_ifnotexists(t *testing.T) {
 		DueTime:  ptr.Of("20s"),
 		Schedule: ptr.Of("@every 5s"),
 	}
-	require.NoError(t, cron.API().Add(cron.Context(), now, job))
+	require.NoError(t, cron.API().Add(cron.Context(), name, job))
 
 	time.Sleep(time.Second * 5)
 	assert.Equal(t, 1, cron.Triggered())


### PR DESCRIPTION
Fixes a go routine leak whereby a counter loop would be created on informer deleted events, even though it has been cleared from the store as it has expired. Previously created a new counter which would be `Run` forever, using resource. Will ignore delete informer events if the counter is no processing.

Updates upsert integration tests which will fail in some timezones.

Adds a go routine leak test to ensure the number of routines falls back close to base after 1000s of executions.