### PR TITLE
counters: gracefully handle stale ExecuteResponse with nil cancel

### DIFF
--- a/internal/engine/queue/loops/counters/counters_test.go
+++ b/internal/engine/queue/loops/counters/counters_test.go
@@ -327,4 +327,30 @@ func Test_counters(t *testing.T) {
 
 		assert.Equal(t, 1, called)
 	})
+
+	t.Run("a stale execute response with matching uid and nil cancel should be ignored", func(t *testing.T) {
+		t.Parallel()
+
+		var idx atomic.Int64
+		idx.Store(999)
+
+		c := &counters{
+			name:    "test-job",
+			idx:     &idx,
+			counter: counterfake.New(),
+		}
+
+		assert.NoError(t, c.Handle(t.Context(), &queue.JobAction{
+			Action: &queue.JobAction_ExecuteResponse{
+				ExecuteResponse: &queue.ExecuteResponse{
+					JobName:    "test-job",
+					CounterKey: "test-key",
+					Uid:        999,
+					Result: &api.TriggerResponse{
+						Result: api.TriggerResponseResult_SUCCESS,
+					},
+				},
+			},
+		}))
+	})
 }

--- a/internal/engine/queue/loops/router/router.go
+++ b/internal/engine/queue/loops/router/router.go
@@ -97,6 +97,7 @@ func (r *router) newCounter(ctx context.Context, jobName string) *counter {
 		IDx:      &idx,
 		Actioner: r.act,
 		Name:     jobName,
+		Log:      r.log,
 	})
 
 	counter := &counter{


### PR DESCRIPTION
Previously, a race condition could cause the counters loop to return a "catastrophic state machine error: lost cancel" when an ExecuteResponse was received after an Informed event had already cleared the cancel function. This condition can occur naturally when jobs are updated during execution.

This commit updates the behavior to treat such responses as stale and harmless. When a matching ExecuteResponse arrives with a nil cancel, the event is now silently ignored and logged at info level. This prevents unnecessary failure scenarios and improves resilience under concurrent job updates.