### PR TITLE
DeletePrefixes: allow non-DNS suffix characters

### DIFF
--- a/internal/engine/handler/handler.go
+++ b/internal/engine/handler/handler.go
@@ -242,7 +242,9 @@ func (h *handler) DeletePrefixes(ctx context.Context, prefixes ...string) error 
 			continue
 		}
 
-		if err := h.validator.JobName(prefix); err != nil {
+		// In cases of non-DNS compatible suffix characters, add a dummy character
+		// to ensure validation passes.
+		if err := h.validator.JobName(prefix + "a"); err != nil {
 			return err
 		}
 	}

--- a/internal/engine/handler/handler_test.go
+++ b/internal/engine/handler/handler_test.go
@@ -292,6 +292,13 @@ func Test_DeletePrefixes(t *testing.T) {
 		api := newAPI(t)
 		require.Error(t, api.DeletePrefixes(t.Context(), "./."))
 	})
+
+	t.Run("non-DNS suffix characters should not error", func(t *testing.T) {
+		t.Parallel()
+
+		api := newAPI(t)
+		require.NoError(t, api.DeletePrefixes(t.Context(), "abc||"))
+	})
 }
 
 func Test_List(t *testing.T) {

--- a/tests/suite/deleteprefixes_test.go
+++ b/tests/suite/deleteprefixes_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package suite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dapr/kit/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/diagridio/go-etcd-cron/api"
+	"github.com/diagridio/go-etcd-cron/tests/framework/cron/integration"
+)
+
+func Test_deleteprefixes(t *testing.T) {
+	t.Parallel()
+
+	cron := integration.NewBase(t, 1)
+
+	job := &api.Job{
+		DueTime: ptr.Of(time.Now().Add(time.Second * 2).Format(time.RFC3339)),
+	}
+
+	require.NoError(t, cron.API().Add(cron.Context(), "def||abc", job))
+	got, err := cron.API().Get(cron.Context(), "def||abc")
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+
+	require.NoError(t, cron.API().DeletePrefixes(cron.Context(), "def"))
+	got, err = cron.API().Get(cron.Context(), "def||abc")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	require.NoError(t, cron.API().Add(cron.Context(), "def||abc", job))
+	got, err = cron.API().Get(cron.Context(), "def||abc")
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+
+	require.NoError(t, cron.API().DeletePrefixes(cron.Context(), "def||"))
+	got, err = cron.API().Get(cron.Context(), "def||abc")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}


### PR DESCRIPTION
Update the `DeletePrefixes` input validation to allow non-DNS suffix characters such as `||`. This allows for more flexible prefix definitions, accommodating various use cases beyond standard DNS formats.