### PR TITLE
Fix informer panic when watch fails

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -69,6 +69,7 @@ func New(opts Options) (Interface, error) {
 		Key:         opts.Key,
 		Client:      opts.Client,
 		Partitioner: opts.Partitioner,
+		Log:         opts.Log,
 	})
 
 	schedBuilder := scheduler.NewBuilder()


### PR DESCRIPTION
If the informer watch is no longer or misses the previous KV of a delete due to compaction or leadership loss, the informer would panic. Updates to catch the nil pointer, and gracefully exit in order to rebuild the queue when we can.