### PR TITLE
Informer: retry failed sync base until successful

### DIFF
--- a/internal/engine/informer/informer_test.go
+++ b/internal/engine/informer/informer_test.go
@@ -348,7 +348,7 @@ func Test_handleEvent(t *testing.T) {
 				Partitioner: part,
 				Key:         key,
 			})
-			gotEvent, err := i.handleEvent(testInLoop.ev)
+			gotEvent, err := i.handleEvent(testInLoop.ev, false)
 			assert.Equal(t, testInLoop.expEvent, gotEvent, "%v != %v", testInLoop.expEvent, gotEvent)
 			assert.Equal(t, testInLoop.expErr, err != nil, "%v", err)
 		})


### PR DESCRIPTION
Prevent the entire cron from shutting down in the event that the base syner failed, likely due to transient compaction errors. Instead, log the error and retry the sync base after 1 second. Still respect the context cancellation, so that the cron can be stopped if needed.