### PR TITLE
informer: harden Watch against compaction, cancellation, channel death

### DIFF
--- a/internal/engine/informer/informer.go
+++ b/internal/engine/informer/informer.go
@@ -109,7 +109,34 @@ func (i *Informer) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case evs := <-ch:
+		case evs, ok := <-ch:
+			if !ok {
+				// Watch channel closed by the etcd client. The clientv3 watcher
+				// has given up reconnecting, so we cannot rely on it any
+				// further. Returning nil makes the engine tear down and the
+				// cron leadership loop restart it, which performs a fresh
+				// SyncBase + SyncUpdates.
+				i.log.Info("watch channel closed, backing out to rebuild queue")
+				return nil
+			}
+
+			if evs.Canceled {
+				i.log.Info("watch canceled by server, backing out to rebuild queue",
+					"compactRevision", evs.CompactRevision, "err", evs.Err())
+				return nil
+			}
+
+			if err := evs.Err(); err != nil {
+				i.log.Error(err, "watch error, backing out to rebuild queue")
+				return nil
+			}
+
+			if evs.CompactRevision != 0 {
+				i.log.Info("watch revision compacted, backing out to rebuild queue",
+					"compactRevision", evs.CompactRevision)
+				return nil
+			}
+
 			for _, ev := range evs.Events {
 				events, err := i.handleEvent(ev, false)
 				if err != nil {

--- a/internal/engine/informer/informer.go
+++ b/internal/engine/informer/informer.go
@@ -116,6 +116,14 @@ func (i *Informer) Run(ctx context.Context) error {
 				// further. Returning nil makes the engine tear down and the
 				// cron leadership loop restart it, which performs a fresh
 				// SyncBase + SyncUpdates.
+				//
+				// On a normal shutdown, the etcd client closes its WatchChan
+				// when ctx is cancelled. select may pick this arm instead of
+				// ctx.Done(), so suppress the log to avoid misleading
+				// "watch channel closed" messages on every clean stop.
+				if ctx.Err() != nil {
+					return nil
+				}
 				i.log.Info("watch channel closed, backing out to rebuild queue")
 				return nil
 			}

--- a/internal/engine/informer/informer.go
+++ b/internal/engine/informer/informer.go
@@ -128,20 +128,17 @@ func (i *Informer) Run(ctx context.Context) error {
 				return nil
 			}
 
-			if evs.Canceled {
-				i.log.Info("watch canceled by server, backing out to rebuild queue",
-					"compactRevision", evs.CompactRevision, "err", evs.Err())
-				return nil
-			}
-
-			if err := evs.Err(); err != nil {
-				i.log.Error(err, "watch error, backing out to rebuild queue")
-				return nil
-			}
-
-			if evs.CompactRevision != 0 {
-				i.log.Info("watch revision compacted, backing out to rebuild queue",
-					"compactRevision", evs.CompactRevision)
+			// Any of Canceled, a non-nil Err(), or a non-zero CompactRevision
+			// means the watch has ended and we cannot trust it for further
+			// events. They overlap (etcd typically sets Canceled together
+			// with CompactRevision, and Err() derives from those fields),
+			// so a single branch handles all of them and surfaces the
+			// available diagnostic fields in one log line.
+			if evs.Canceled || evs.CompactRevision != 0 || evs.Err() != nil {
+				i.log.Info("watch ended, backing out to rebuild queue",
+					"canceled", evs.Canceled,
+					"compactRevision", evs.CompactRevision,
+					"err", evs.Err())
 				return nil
 			}
 

--- a/internal/engine/informer/informer_test.go
+++ b/internal/engine/informer/informer_test.go
@@ -19,10 +19,23 @@ import (
 
 	"github.com/diagridio/go-etcd-cron/internal/api/queue"
 	"github.com/diagridio/go-etcd-cron/internal/api/stored"
+	"github.com/diagridio/go-etcd-cron/internal/client/api"
 	"github.com/diagridio/go-etcd-cron/internal/key"
 	"github.com/diagridio/go-etcd-cron/internal/leadership/partitioner"
 	"github.com/diagridio/go-etcd-cron/tests/framework/etcd"
 )
+
+// watchOverride wraps an api.Interface and replaces its Watch implementation
+// with a caller-supplied function so tests can drive specific watch
+// transitions (closed channel, Canceled, CompactRevision).
+type watchOverride struct {
+	api.Interface
+	watchFn func(context.Context, string, ...clientv3.OpOption) clientv3.WatchChan
+}
+
+func (w *watchOverride) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+	return w.watchFn(ctx, key, opts...)
+}
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
@@ -245,6 +258,82 @@ func Test_Run(t *testing.T) {
 		case <-time.After(time.Second):
 		}
 	})
+}
+
+func Test_Run_watchTermination(t *testing.T) {
+	t.Parallel()
+
+	k, err := key.New(key.Options{Namespace: "abc", ID: "0"})
+	require.NoError(t, err)
+	part, err := partitioner.New(partitioner.Options{
+		Key: k,
+		Leaders: []*mvccpb.KeyValue{
+			{Key: []byte("abc/leader/0")},
+		},
+	})
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		watchFn func(context.Context, string, ...clientv3.OpOption) clientv3.WatchChan
+	}{
+		"closed channel exits Run": {
+			watchFn: func(_ context.Context, _ string, _ ...clientv3.OpOption) clientv3.WatchChan {
+				ch := make(chan clientv3.WatchResponse)
+				close(ch)
+				return ch
+			},
+		},
+		"Canceled response exits Run": {
+			watchFn: func(_ context.Context, _ string, _ ...clientv3.OpOption) clientv3.WatchChan {
+				ch := make(chan clientv3.WatchResponse, 1)
+				ch <- clientv3.WatchResponse{Canceled: true}
+				close(ch)
+				return ch
+			},
+		},
+		"CompactRevision response exits Run": {
+			watchFn: func(_ context.Context, _ string, _ ...clientv3.OpOption) clientv3.WatchChan {
+				ch := make(chan clientv3.WatchResponse, 1)
+				ch <- clientv3.WatchResponse{CompactRevision: 42}
+				close(ch)
+				return ch
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &watchOverride{
+				Interface: etcd.Embedded(t),
+				watchFn:   tc.watchFn,
+			}
+
+			i, _ := New(Options{
+				Partitioner: part,
+				Client:      client,
+				Key:         k,
+			})
+
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(cancel)
+
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- i.Run(ctx)
+			}()
+
+			require.NoError(t, i.Ready(ctx))
+
+			select {
+			case err := <-errCh:
+				require.NoError(t, err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("Run did not exit after watch termination - informer is hot-spinning on closed channel")
+			}
+		})
+	}
 }
 
 func Test_handleEvent_nonbase(t *testing.T) {

--- a/internal/engine/informer/syncer.go
+++ b/internal/engine/informer/syncer.go
@@ -111,5 +111,13 @@ func (s *syncer) SyncUpdates(ctx context.Context) clientv3.WatchChan {
 	if s.rev == 0 {
 		panic("unexpected revision = 0. Calling SyncUpdates before SyncBase finishes?")
 	}
-	return s.c.Watch(ctx, s.prefix, clientv3.WithPrefix(), clientv3.WithRev(s.rev+1), clientv3.WithPrevKV())
+	// WithProgressNotify keeps the watcher's tracked revision close to head
+	// so that periodic compaction does not force a re-SyncBase when the watch
+	// is otherwise idle.
+	return s.c.Watch(ctx, s.prefix,
+		clientv3.WithPrefix(),
+		clientv3.WithRev(s.rev+1),
+		clientv3.WithPrevKV(),
+		clientv3.WithProgressNotify(),
+	)
 }


### PR DESCRIPTION
The informer is a long-lived prefix watch over a high-churn keyspace (scheduler jobs feeding workflows). Three failure modes were swallowed:

- A closed WatchChan turned the receive arm into a hot spin on zero-value WatchResponses.
- Canceled, Err() and CompactRevision on each response were never inspected, so server-side cancellation or compaction overtaking the watcher silently stopped event delivery.
- The watcher's tracked revision drifted behind head while idle, so periodic compaction could force the next event into ErrCompacted.

syncer.go now passes clientv3.WithProgressNotify so the client advances its internal cursor on idle watches. informer.go checks ok on the receive, plus Canceled/Err/CompactRevision on each response; any of these logs and returns nil, reusing the existing "back out to rebuild queue" path that unwinds to cron.runEngine's Reelect loop for a fresh SyncBase + SyncUpdates.