### PR TITLE
validator: align job name validation with name policy, allow special characters

### DIFF
--- a/internal/api/validator/validator.go
+++ b/internal/api/validator/validator.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 // maxJobNameLength bounds the job name length to keep etcd keys and storage
@@ -18,41 +19,36 @@ const maxJobNameLength = 512
 
 // forbiddenJobNameChars are characters that must never appear in a job name.
 // '/' and '\' would let a name escape the etcd key path partition; '#' and '?'
-// and NUL would allow injection when the name is embedded in a URL path or
-// query. '||' remains reserved as the internal name delimiter, but a single
-// '|' is permitted.
-const forbiddenJobNameChars = "#?\x00/\\"
+// would allow injection when the name is embedded in a URL path or query. NUL
+// and other control characters are rejected separately. '||' remains reserved
+// as the internal name delimiter, but a single '|' is permitted.
+const forbiddenJobNameChars = "#?/\\"
 
 // Options is a struct that contains options for the validator.
 type Options struct {
 	// JobNameSanitizer is a replacer that sanitizes job names before name
-	// validation. Retained for API compatibility; the default validation no
-	// longer depends on it.
+	// validation. Retained for API compatibility; validation no longer depends
+	// on it and it is not applied (see JobName).
 	JobNameSanitizer *strings.Replacer
 }
 
 // Validator validates API request payloads.
-type Validator struct {
-	jobNameSanitizer *strings.Replacer
-}
+type Validator struct{}
 
 func New(opts Options) *Validator {
-	jobNameSanitizer := opts.JobNameSanitizer
-	if jobNameSanitizer == nil {
-		jobNameSanitizer = strings.NewReplacer()
-	}
-	return &Validator{
-		jobNameSanitizer: jobNameSanitizer,
-	}
+	return &Validator{}
 }
 
 // JobName validates a job name string. Names may contain any character except
-// '/', '\', '#', '?', NUL and control characters, and may not be the path
-// traversal sequences "." or "..". This mirrors the character policy applied to
-// names at the Dapr API edge so that anything accepted there can be scheduled.
+// '/', '\', '#', '?', and control characters (including NUL and the Unicode C1
+// range), and may not be the path traversal sequences "." or "..". This mirrors
+// the character policy applied to names at the Dapr API edge so that anything
+// accepted there can be scheduled.
+//
+// The original input is validated as-is; no sanitization is applied, since the
+// stored etcd key uses the original name and any sanitization here would let a
+// forbidden character slip through to storage.
 func (v *Validator) JobName(name string) error {
-	name = v.jobNameSanitizer.Replace(name)
-
 	if len(name) == 0 {
 		return errors.New("job name cannot be empty")
 	}
@@ -62,11 +58,11 @@ func (v *Validator) JobName(name string) error {
 	}
 
 	if strings.ContainsAny(name, forbiddenJobNameChars) {
-		return fmt.Errorf("job name is invalid %q: must not contain '/', '\\', '#', '?' or NUL", name)
+		return fmt.Errorf("job name is invalid %q: must not contain '/', '\\', '#' or '?'", name)
 	}
 
-	for i := range name {
-		if b := name[i]; b < 0x20 || b == 0x7f {
+	for _, r := range name {
+		if unicode.IsControl(r) {
 			return fmt.Errorf("job name is invalid %q: must not contain control characters", name)
 		}
 	}

--- a/internal/api/validator/validator.go
+++ b/internal/api/validator/validator.go
@@ -24,18 +24,10 @@ const maxJobNameLength = 512
 // as the internal name delimiter, but a single '|' is permitted.
 const forbiddenJobNameChars = "#?/\\"
 
-// Options is a struct that contains options for the validator.
-type Options struct {
-	// JobNameSanitizer is a replacer that sanitizes job names before name
-	// validation. Retained for API compatibility; validation no longer depends
-	// on it and it is not applied (see JobName).
-	JobNameSanitizer *strings.Replacer
-}
-
 // Validator validates API request payloads.
 type Validator struct{}
 
-func New(opts Options) *Validator {
+func New() *Validator {
 	return &Validator{}
 }
 

--- a/internal/api/validator/validator.go
+++ b/internal/api/validator/validator.go
@@ -9,14 +9,25 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"k8s.io/apimachinery/pkg/util/validation"
 )
+
+// maxJobNameLength bounds the job name length to keep etcd keys and storage
+// from growing unbounded. It is generous: full actor reminder names
+// (actorreminder||namespace||type||id||name) are typically well under this.
+const maxJobNameLength = 512
+
+// forbiddenJobNameChars are characters that must never appear in a job name.
+// '/' and '\' would let a name escape the etcd key path partition; '#' and '?'
+// and NUL would allow injection when the name is embedded in a URL path or
+// query. '||' remains reserved as the internal name delimiter, but a single
+// '|' is permitted.
+const forbiddenJobNameChars = "#?\x00/\\"
 
 // Options is a struct that contains options for the validator.
 type Options struct {
 	// JobNameSanitizer is a replacer that sanitizes job names before name
-	// validation.
+	// validation. Retained for API compatibility; the default validation no
+	// longer depends on it.
 	JobNameSanitizer *strings.Replacer
 }
 
@@ -28,24 +39,40 @@ type Validator struct {
 func New(opts Options) *Validator {
 	jobNameSanitizer := opts.JobNameSanitizer
 	if jobNameSanitizer == nil {
-		jobNameSanitizer = strings.NewReplacer("_", "", ":", "", "-", "", " ", "")
+		jobNameSanitizer = strings.NewReplacer()
 	}
 	return &Validator{
 		jobNameSanitizer: jobNameSanitizer,
 	}
 }
 
-// JobName validates a job name string.
+// JobName validates a job name string. Names may contain any character except
+// '/', '\', '#', '?', NUL and control characters, and may not be the path
+// traversal sequences "." or "..". This mirrors the character policy applied to
+// names at the Dapr API edge so that anything accepted there can be scheduled.
 func (v *Validator) JobName(name string) error {
+	name = v.jobNameSanitizer.Replace(name)
+
 	if len(name) == 0 {
 		return errors.New("job name cannot be empty")
 	}
 
-	name = v.jobNameSanitizer.Replace(name)
-	for _, segment := range strings.Split(strings.ToLower(name), "||") {
-		if errs := validation.IsDNS1123Subdomain(segment); len(errs) > 0 {
-			return fmt.Errorf("job name is invalid %q: %s", name, strings.Join(errs, ", "))
+	if len(name) > maxJobNameLength {
+		return fmt.Errorf("job name is invalid %q: must be at most %d characters", name, maxJobNameLength)
+	}
+
+	if strings.ContainsAny(name, forbiddenJobNameChars) {
+		return fmt.Errorf("job name is invalid %q: must not contain '/', '\\', '#', '?' or NUL", name)
+	}
+
+	for i := range name {
+		if b := name[i]; b < 0x20 || b == 0x7f {
+			return fmt.Errorf("job name is invalid %q: must not contain control characters", name)
 		}
+	}
+
+	if name == "." || name == ".." {
+		return fmt.Errorf("job name is invalid %q: must not be a path traversal sequence", name)
 	}
 
 	return nil

--- a/internal/api/validator/validator_test.go
+++ b/internal/api/validator/validator_test.go
@@ -70,7 +70,7 @@ func Test_JobName(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			err := New(Options{}).JobName(test.name)
+			err := New().JobName(test.name)
 			assert.Equal(t, test.expErr, err != nil, "%v", err)
 		})
 	}

--- a/internal/api/validator/validator_test.go
+++ b/internal/api/validator/validator_test.go
@@ -33,6 +33,7 @@ func Test_JobName(t *testing.T) {
 		{desc: "nul byte", name: "foo\x00bar", expErr: true},
 		{desc: "newline control char", name: "foo\nbar", expErr: true},
 		{desc: "del control char", name: "foo\x7fbar", expErr: true},
+		{desc: "unicode c1 control nel", name: "foo\u0085bar", expErr: true},
 		{desc: "too long", name: strings.Repeat("a", maxJobNameLength+1), expErr: true},
 
 		{desc: "single dot in middle", name: "fo.o", expErr: false},
@@ -48,6 +49,7 @@ func Test_JobName(t *testing.T) {
 		{desc: "underscore and hyphen", name: "foo.BAR_f-oo||foo", expErr: false},
 		{desc: "single pipe in segment", name: "foo|bar", expErr: false},
 		{desc: "at sign", name: "my@reminder", expErr: false},
+		{desc: "non-ascii letters", name: "café||piñata", expErr: false},
 		{
 			desc:   "workflow reminder name",
 			name:   "actorreminder||dapr-tests||dapr.internal.dapr-tests.perf-workflowsapp.workflow||24b3fbad-0db5-4e81-a272-71f6018a66a6||start-4NYDFil-",

--- a/internal/api/validator/validator_test.go
+++ b/internal/api/validator/validator_test.go
@@ -6,6 +6,7 @@ Licensed under the MIT License.
 package validator
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,93 +16,57 @@ func Test_JobName(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		desc   string
 		name   string
 		expErr bool
 	}{
+		{desc: "empty", name: "", expErr: true},
+		{desc: "slash", name: "/", expErr: true},
+		{desc: "wrapped in slashes", name: "/foo/", expErr: true},
+		{desc: "trailing slash", name: "foo/", expErr: true},
+		{desc: "dot", name: ".", expErr: true},
+		{desc: "double dot", name: "..", expErr: true},
+		{desc: "dot slash dot", name: "./.", expErr: true},
+		{desc: "backslash", name: "foo\\bar", expErr: true},
+		{desc: "hash", name: "foo#bar", expErr: true},
+		{desc: "question mark", name: "foo?bar", expErr: true},
+		{desc: "nul byte", name: "foo\x00bar", expErr: true},
+		{desc: "newline control char", name: "foo\nbar", expErr: true},
+		{desc: "del control char", name: "foo\x7fbar", expErr: true},
+		{desc: "too long", name: strings.Repeat("a", maxJobNameLength+1), expErr: true},
+
+		{desc: "single dot in middle", name: "fo.o", expErr: false},
+		{desc: "consecutive dots in middle", name: "fo...o", expErr: false},
+		{desc: "max length", name: strings.Repeat("a", maxJobNameLength), expErr: false},
+		{desc: "simple", name: "valid", expErr: false},
+		{desc: "bare delimiter", name: "||", expErr: false},
+		{desc: "trailing delimiter", name: "foo||", expErr: false},
+		{desc: "leading delimiter", name: "||foo", expErr: false},
+		{desc: "two segments", name: "foo||foo", expErr: false},
+		{desc: "dotted segment", name: "foo.bar||foo", expErr: false},
+		{desc: "uppercase preserved", name: "foo.BAR||foo", expErr: false},
+		{desc: "underscore and hyphen", name: "foo.BAR_f-oo||foo", expErr: false},
+		{desc: "single pipe in segment", name: "foo|bar", expErr: false},
+		{desc: "at sign", name: "my@reminder", expErr: false},
 		{
-			name:   "",
-			expErr: true,
-		},
-		{
-			name:   "/",
-			expErr: true,
-		},
-		{
-			name:   "/foo/",
-			expErr: true,
-		},
-		{
-			name:   "foo/",
-			expErr: true,
-		},
-		{
-			name:   ".",
-			expErr: true,
-		},
-		{
-			name:   "..",
-			expErr: true,
-		},
-		{
-			name:   "./.",
-			expErr: true,
-		},
-		{
-			name:   "fo.o",
-			expErr: false,
-		},
-		{
-			name:   "fo...o",
-			expErr: true,
-		},
-		{
-			name:   "valid",
-			expErr: false,
-		},
-		{
-			name:   "||",
-			expErr: true,
-		},
-		{
-			name:   "foo||",
-			expErr: true,
-		},
-		{
-			name:   "||foo",
-			expErr: true,
-		},
-		{
-			name:   "foo||foo",
-			expErr: false,
-		},
-		{
-			name:   "foo.bar||foo",
-			expErr: false,
-		},
-		{
-			name:   "foo.BAR||foo",
-			expErr: false,
-		},
-		{
-			name:   "foo.BAR_f-oo||foo",
-			expErr: false,
-		},
-		{
+			desc:   "workflow reminder name",
 			name:   "actorreminder||dapr-tests||dapr.internal.dapr-tests.perf-workflowsapp.workflow||24b3fbad-0db5-4e81-a272-71f6018a66a6||start-4NYDFil-",
 			expErr: false,
 		},
 		{
-			name:   "aABVCD||dapr-::123:123||dapr.internal.dapr-tests.perf-workflowsapp.workflow||24b3fbad-0db5-4e81-a272-71f6018a66a6||start-4NYDFil-",
+			desc:   "schreder actor id with pipes and at sign",
+			name:   "actorreminder||dapr-tests||SmokeDetectorActor||nexus-fire-safety-api||SmokeDetectorGroupMonitorActor||Nexus|6671cfbe7f48af247700a24b||SmokeDetectorGroupInformation||my@reminder|name",
 			expErr: false,
 		},
 		{
+			desc:   "colons and spaces in segments",
 			name:   "aABVCD||dapr-::123:123||dapr.internal.dapr-tests.perf-  workflowsapp.workflow||24b3fbad-0db5-4e81        -a272-71f6018a66a6||start-4NYDFil-",
 			expErr: false,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			err := New(Options{}).JobName(test.name)
 			assert.Equal(t, test.expErr, err != nil, "%v", err)

--- a/internal/engine/handler/handler.go
+++ b/internal/engine/handler/handler.go
@@ -38,10 +38,6 @@ type Options struct {
 	SchedulerBuilder *scheduler.Builder
 	Queue            *queue.Queue
 	Informer         *informer.Informer
-
-	// JobNameSanitizer is a replacer that sanitizes job names before name
-	// validation.
-	JobNameSanitizer *strings.Replacer
 }
 
 // Interface is the internal API that implements the API backend.
@@ -102,13 +98,11 @@ func New(opts Options) Interface {
 		client:       opts.Client,
 		key:          opts.Key,
 		schedBuilder: opts.SchedulerBuilder,
-		validator: validator.New(validator.Options{
-			JobNameSanitizer: opts.JobNameSanitizer,
-		}),
-		queue:    opts.Queue,
-		informer: opts.Informer,
-		readyCh:  make(chan struct{}),
-		closeCh:  make(chan struct{}),
+		validator:    validator.New(),
+		queue:        opts.Queue,
+		informer:     opts.Informer,
+		readyCh:      make(chan struct{}),
+		closeCh:      make(chan struct{}),
 	}
 }
 


### PR DESCRIPTION
Job names were validated by splitting on the "||" delimiter and running `IsDNS1123Subdomain` on each segment. `DNS-1123` rejects perfectly safe characters such as '|' and '@', and (because the validator lowercases before checking) the surfaced "a lowercase RFC 1123 subdomain ..." error was misleading, since uppercase is in fact accepted.

In Dapr this validation sits behind names that are already filtered at the API edge, where the accepted character set is much broader. The mismatch meant actor reminders failed to register for actor IDs containing '|' or '||' even though those same IDs work for actor invocation and state.

JobName now rejects only the characters that are actually unsafe: '/' and '\' (which would let a name escape the etcd key path partition), '#', '?' and NUL and other control characters (which allow injection when the name is embedded in a URL path or in logs), and the exact path traversal sequences "." and "..". Everything else, including '|', '@', uppercase and a single '|' within a segment, is permitted. The "||" sequence remains the reserved name delimiter. A maximum length is enforced to bound etcd key and storage growth, replacing the implicit per-segment limit that DNS-1123 used to provide.

The JobNameSanitizer option is retained for API compatibility but the default no longer strips characters, since validation no longer depends on it. Error messages now describe the characters that are actually disallowed. 