### PR TITLE
cron: add pluggable storage backend registry

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -33,6 +33,9 @@ type Options struct {
 	// Log is the logger to use for logging.
 	Log logr.Logger
 
+	Backend       *string
+	BackendConfig any
+
 	// Client is the etcd client to use for storing cron entries.
 	Client *clientv3.Client
 
@@ -96,8 +99,28 @@ type cron struct {
 	running atomic.Bool
 }
 
-// New creates a new cron instance.
+func init() {
+	Register(BackendEtcd, newEtcd)
+}
+
+// New creates a new cron instance using the backend selected by Options.Backend
+// (or the last-registered backend if empty).
 func New(opts Options) (api.Interface, error) {
+	var backend string
+	if opts.Backend != nil {
+		backend = *opts.Backend
+	}
+
+	factory, err := resolveFactory(backend)
+	if err != nil {
+		return nil, err
+	}
+
+	return factory(opts)
+}
+
+// newEtcd is the Factory for the built-in etcd backend.
+func newEtcd(opts Options) (api.Interface, error) {
 	if opts.TriggerFn == nil {
 		return nil, errors.New("trigger function is required")
 	}

--- a/cron/registry.go
+++ b/cron/registry.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package cron
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/diagridio/go-etcd-cron/api"
+)
+
+// BackendEtcd is the name of the built-in etcd backend, registered by default.
+const BackendEtcd = "etcd"
+
+// Factory builds a cron api.Interface for a named backend from the given
+// Options. Backend-specific configuration is carried opaquely in
+// Options.BackendConfig; the built-in etcd backend instead reads the dedicated
+// Options fields (Client, Namespace).
+type Factory func(opts Options) (api.Interface, error)
+
+var (
+	registryMu     sync.RWMutex
+	registry       = make(map[string]Factory)
+	lastRegistered string
+)
+
+// Register registers a cron backend Factory under the given name. It is
+// typically called from a backend package's init(). The most recently
+// registered backend becomes the default when Options.Backend is empty ("use
+// last registered"), so a blank import of an out-of-tree backend overrides the
+// built-in etcd default without any other code change. An explicit
+// Options.Backend always takes precedence over the last-registered default.
+func Register(name string, f Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[name] = f
+	lastRegistered = name
+}
+
+// resolveFactory returns the Factory for the named backend. An empty name
+// selects the last-registered backend.
+func resolveFactory(name string) (Factory, error) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	if name == "" {
+		name = lastRegistered
+	}
+	if name == "" {
+		return nil, errors.New("no cron backend registered")
+	}
+
+	f, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("cron backend %q not registered", name)
+	}
+
+	return f, nil
+}

--- a/cron/registry_test.go
+++ b/cron/registry_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright (c) 2025 Diagrid Inc.
+Licensed under the MIT License.
+*/
+
+package cron
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/diagridio/go-etcd-cron/api"
+)
+
+// saveRegistry snapshots the global registry state and restores it on cleanup so
+// tests that register backends do not leak into one another.
+func saveRegistry(t *testing.T) {
+	t.Helper()
+	registryMu.Lock()
+	savedReg := make(map[string]Factory, len(registry))
+	for k, v := range registry {
+		savedReg[k] = v
+	}
+	savedLast := lastRegistered
+	registryMu.Unlock()
+
+	t.Cleanup(func() {
+		registryMu.Lock()
+		registry = savedReg
+		lastRegistered = savedLast
+		registryMu.Unlock()
+	})
+}
+
+func Test_resolveFactory(t *testing.T) {
+	t.Run("empty backend resolves to the built-in etcd backend by default", func(t *testing.T) {
+		saveRegistry(t)
+		f, err := resolveFactory("")
+		require.NoError(t, err)
+		assert.NotNil(t, f)
+	})
+
+	t.Run("explicit etcd backend resolves", func(t *testing.T) {
+		saveRegistry(t)
+		f, err := resolveFactory(BackendEtcd)
+		require.NoError(t, err)
+		assert.NotNil(t, f)
+	})
+
+	t.Run("unknown backend errors", func(t *testing.T) {
+		saveRegistry(t)
+		_, err := resolveFactory("does-not-exist")
+		assert.Error(t, err)
+	})
+
+	t.Run("last registered backend wins when backend is empty", func(t *testing.T) {
+		saveRegistry(t)
+
+		var called bool
+		Register("fake", func(Options) (api.Interface, error) {
+			called = true
+			return nil, nil
+		})
+
+		// Empty backend should now select "fake" (last registered).
+		f, err := resolveFactory("")
+		require.NoError(t, err)
+		_, _ = f(Options{})
+		assert.True(t, called, "expected last-registered backend to be selected")
+	})
+
+	t.Run("explicit backend overrides the last-registered default", func(t *testing.T) {
+		saveRegistry(t)
+
+		Register("fake", func(Options) (api.Interface, error) { return nil, nil })
+
+		// Even though "fake" was registered last, an explicit "etcd" wins.
+		f, err := resolveFactory(BackendEtcd)
+		require.NoError(t, err)
+		assert.NotNil(t, f)
+	})
+}


### PR DESCRIPTION
Allow cron storage backends other than the built-in etcd backend to be plugged in without forking. cron.New now resolves a registered backend Factory by name rather than constructing the etcd engine directly.